### PR TITLE
Ensures the theme is seen when you build the docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,5 @@ RUN service postgresql restart \
   && drush tripal:trp-import-types --username=drupaladmin --collection_id=general_chado \
   && drush tripal:trp-import-types --username=drupaladmin --collection_id=germplasm_chado \
   && drush theme:enable trpcultivatetheme --yes \
+  && drush config-set system.theme default trpcultivatetheme --yes \
   && drush cr

--- a/README.md
+++ b/README.md
@@ -6,11 +6,19 @@ This theme is intended to provide a base for developing custom themes for projec
 
 <br clear="right"/>
 
+## Customizing this theme
+
+You can set the primary base colour using the following drush command where you substitute `#f54278` for whatever hex code you would like to use.
+
+```
+drush config:set trpcultivatetheme.settings base_primary_color '#f54278'
+```
+
 ## Development
 
 ### Docker
 
-As you may have noticed there is a dockerfile in this repository. The recommended way to contribute to this theme is the same as the recommendation for core development: use docker please :-) 
+As you may have noticed there is a dockerfile in this repository. The recommended way to contribute to this theme is the same as the recommendation for core development: use docker please :-)
 
 ```bash
 git clone https://github.com/TripalCultivate/TripalCultivate-Theme trpcultivatetheme
@@ -24,6 +32,6 @@ This docker image/container will have a fully functioning Tripal 4 site based on
 
 ### Olivero as a Base Theme
 
-This theme uses the core Olivero theme as a base theme. As of 2024Feb this is not technically recommended as the markup of Olivero is not fixed. You can see the current status / recommendation on using Oliverio as a subtheme in [Drupal Issue #3190946 - [META] Subtheming Olivero](https://www.drupal.org/project/drupal/issues/3190946). 
+This theme uses the core Olivero theme as a base theme. As of 2024Feb this is not technically recommended as the markup of Olivero is not fixed. You can see the current status / recommendation on using Oliverio as a subtheme in [Drupal Issue #3190946 - [META] Subtheming Olivero](https://www.drupal.org/project/drupal/issues/3190946).
 
 As you can see in [comment #19 of that issue](https://www.drupal.org/project/drupal/issues/3190946#comment-15443899), we've decided to use Olivero as a base theme despite the recommendation not to. This is because we believe that the effort to update this theme with any markup changes in Olivero is likely less work then the other options we considered. If we had copied Oliverio and renamed it for our own purposes as suggested, then it would have been a lot of work to re-incorporate any updates/fixes made to Olivero in core. This is because with the names of all the files changed, we could not do a direct comparison of files or git merge. The theme landscape at the beginning of 2024 is still very sparse for good Drupal themes so we couldn't just use a more stable theme as a base. There are a number of Bootstrap base themes available but the community has fractured quite a bit causing it to be confusing to know which one to use for long term sustainability. Furthermore, we did not like the base themeing provided by these base themes.

--- a/config/install/trpcultivatetheme.settings.yml
+++ b/config/install/trpcultivatetheme.settings.yml
@@ -12,4 +12,4 @@ third_party_settings:
     module_link: true
 mobile_menu_all_widths: 0
 site_branding_bg_color: default
-base_primary_color: '#1b9ae4'
+base_primary_color: '#3C8700'

--- a/trpcultivatetheme.theme
+++ b/trpcultivatetheme.theme
@@ -10,6 +10,13 @@
  */
 function trpcultivatetheme_preprocess_html(array &$variables): void {
 
+  // Ensure the colour-related CSS variables get set.
+  // Convert custom hex to hsl so we can use the hue value
+  $brand_color_hex = theme_get_setting('base_primary_color') ?? '#3C8700';
+  [$h, $s, $l] = _olivero_hex_to_hsl($brand_color_hex);
+
+  $variables['html_attributes']->setAttribute('style', "--color--primary-hue:$h;--color--primary-saturation:$s%;--color--primary-lightness:$l");
+
 }
 
 /**


### PR DESCRIPTION
Previously when you build the docker, you were presented with the base blue olivero styling. This PR, ensures that this theme is set as the default.

Additionally, this PR ensures that the default primary colour for this theme in the YAML is the same as in the settings form AND ensures the CSS variables are updated.

## Testing

Build a docker image and start a container. 
```
docker build --build-arg drupalversion=10.2.x-dev --build-arg phpversion=8.3 --tag=trpcultivate-theme:4x ./
docker run --publish=80:80 -tid --name=theme4x --volume=`pwd`:/var/www/drupal/web/themes/trpcultivatetheme trpcultivate-theme:4x
docker exec theme4x service postgresql restart
```

You should see the following on this branch:
![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/1566301/0b622a6d-335c-4b04-ba02-1210e4ef37bf)

Change the base theme colour using drush and ensure that you see the new colour. For example, the following command changes the primary colour to a warm fuchsia colour.
```
drush config:set trpcultivatetheme.settings base_primary_color '#f54278' --yes
```
![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/1566301/c1aa156f-d6a1-450b-b288-0029d792ba69)
