### PR TITLE
Ensure the theme detects templates and add one for the frontpage.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,16 @@ ARG phpversion='8.3'
 FROM tripalproject/tripaldocker:drupal${drupalversion}-php${phpversion}-pgsql13-noChado
 
 ARG chadoschema='testchado'
+
+## Setup this container to show theme debugging settings
+## such as the template suggestions in the html
+## and rebuilding the theme cache everytime changes are detected.
+WORKDIR /var/www/drupal/web/sites/default/
+RUN cp default.services.yml services.yml \
+  && sed -i '82s/debug: false/debug: true/' services.yml
+
+## Change our working directory to the new theme
 COPY . /var/www/drupal/web/themes/trpcultivatetheme
-
-## This theme uses nodejs and yarn to manage css compilation
-## As such we install that here.
-## RUN apt-get update \
-##   && apt-get install -q -y nodejs npm \
-##   && npm install -g yarn
-
 WORKDIR /var/www/drupal/web/themes/trpcultivatetheme
 
 ## Complete Tripal installation and enable the theme.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ docker exec theme4x service postgresql restart
 
 This docker image/container will have a fully functioning Tripal 4 site based on TripalDocker built using the specified version of Drupal and PHP. [For more details about TripalDocker see the official docs](https://tripaldoc.readthedocs.io/en/latest/install/docker.html#usage).
 
+#### Twig Debugging
+
+The dockerfile sets up the development environment with twig debugging turned on. This adds template suggestions in HTML comments into each page and **refreshes twig template caches as it detects changes in the files**. You do still need to use `drush cr` to see CSS and template changes but it is much more reliable with this setting in place.
+
 ### Olivero as a Base Theme
 
 This theme uses the core Olivero theme as a base theme. As of 2024Feb this is not technically recommended as the markup of Olivero is not fixed. You can see the current status / recommendation on using Oliverio as a subtheme in [Drupal Issue #3190946 - [META] Subtheming Olivero](https://www.drupal.org/project/drupal/issues/3190946).

--- a/css/layout/frontpage.css
+++ b/css/layout/frontpage.css
@@ -1,0 +1,9 @@
+.main-content__container {
+  font-size: 1.5em;
+  line-height: 2em;
+  margin-bottom: 100px;
+  padding: 100px 100px;
+}
+.main-content__container ul {
+  list-style: square outside none;
+}

--- a/templates/layout/page--front.html.twig
+++ b/templates/layout/page--front.html.twig
@@ -46,7 +46,7 @@
  */
 #}
 
-<-- Specifically add frontpage.css to this page. -->
+<!-- Specifically add frontpage.css to this page. -->
 {{ attach_library('trpcultivatetheme/frontpage') }}
 
 <div id="page-wrapper" class="page-wrapper">

--- a/templates/layout/page--front.html.twig
+++ b/templates/layout/page--front.html.twig
@@ -1,0 +1,135 @@
+{#
+/**
+ * @file
+ * Our themes implementation of the front page specifically.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template normally located in the
+ * core/modules/system directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.highlighted: Items for the highlighted region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.content: The main content of the current page.
+ * - page.sidebar: Items for the first sidebar.
+ * - page.featured_bottom_first: Items for the first featured bottom region.
+ * - page.featured_bottom_second: Items for the second featured bottom region.
+ * - page.footer_first: Items for the first footer column.
+ * - page.footer_second: Items for the second footer column.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ * - page.social: Items for the social region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+
+<div id="page-wrapper" class="page-wrapper">
+  <div id="page" class="front-page">
+
+    {% if page.header or page.primary_menu or page.secondary_menu %}
+      <header id="header" class="site-header" data-drupal-selector="site-header" role="banner">
+
+        {# Gets fixed by JavaScript at wide widths. #}
+        <div class="site-header__fixable" data-drupal-selector="site-header-fixable">
+          <div class="site-header__initial">
+            <button class="sticky-header-toggle" data-drupal-selector="sticky-header-toggle" role="switch" aria-controls="site-header__inner" aria-label="{{ 'Sticky header'|t }}" aria-checked="false">
+              <span class="sticky-header-toggle__icon">
+                <span></span>
+                <span></span>
+                <span></span>
+              </span>
+            </button>
+          </div>
+
+          {# Needs to extend full width so box shadow will also extend. #}
+          <div id="site-header__inner" class="site-header__inner" data-drupal-selector="site-header-inner">
+            <div class="container site-header__inner__container">
+
+              {{ page.header }}
+
+              {% if page.primary_menu or page.secondary_menu %}
+                <div class="mobile-buttons" data-drupal-selector="mobile-buttons">
+                  <button class="mobile-nav-button" data-drupal-selector="mobile-nav-button" aria-label="{{ 'Main Menu'|t }}" aria-controls="header-nav" aria-expanded="false">
+                    <span class="mobile-nav-button__label">{{ 'Menu'|t }}</span>
+                    <span class="mobile-nav-button__icon"></span>
+                  </button>
+                </div>
+
+                <div id="header-nav" class="header-nav" data-drupal-selector="header-nav">
+                  {{ page.primary_menu }}
+                  {{ page.secondary_menu }}
+                </div>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      </header>
+    {% endif %}
+
+    <div id="main-wrapper" class="layout-main-wrapper layout-container">
+      <div id="main" class="layout-main">
+        <div class="main-content">
+          <a id="main-content" tabindex="-1"></a>
+          {{ page.hero }}
+          <div class="main-content__container container">
+            {{ page.highlighted }}
+
+            <!-- Current Tripal cultivate information as a placeholder until we get the frontpage in place. -->
+            <div style="font-size:1.5em; line-height: 2em; margin-bottom: 100px; padding: 100px 100px;">
+            <p>Tripal Cultivate is a collection of Tripal extension packages focused on providing intuitive data management support for breeding and pre-breeding activities to help you to</p>
+            <ul style="list-style: square outside none;">
+              <li>Diversify your crossing block with intuitive germplasm search form integrating passport, phenotypic and genotypic data.</li>
+              <li>Streamline project management and easily incorporate pre-breeding data into your breeding workflow with a shared platform.</li>
+              <ul>
+                <li>Ensure germplasm information is correctly associated with pre-breeding research data.</li>
+                <li>Access genotypic and phenotypic data from ongoing pre-breeding research studies when searching for parent material.</li>
+                <li>Easily test tools developed for pre-breeding analysis on breeding material due to shared data storage and formats.</li>
+              </ul>
+              <li>Customize your site by introducing tech savvy staff to built-in administrative interfaces and a vast collection of pluggable themes (i.e. change styles) and modules (i.e. add functionality) provided by Drupal and Tripal international communities.</li>
+              <li>Integrate new visualization and data analysis tools with less developer-time due to our extensive APIs and modular, open-source framework.</li>
+            </ul>
+            </div>
+
+
+          </div>
+        </div>
+        <div class="social-bar">
+          {{ page.social }}
+        </div>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="site-footer__inner container">
+        {{ page.footer_top }}
+        {{ page.footer_bottom }}
+      </div>
+    </footer>
+
+    <div class="overlay" data-drupal-selector="overlay"></div>
+
+  </div>
+</div>

--- a/templates/layout/page--front.html.twig
+++ b/templates/layout/page--front.html.twig
@@ -46,6 +46,9 @@
  */
 #}
 
+<-- Specifically add frontpage.css to this page. -->
+{{ attach_library('trpcultivatetheme/frontpage') }}
+
 <div id="page-wrapper" class="page-wrapper">
   <div id="page" class="front-page">
 
@@ -98,9 +101,8 @@
             {{ page.highlighted }}
 
             <!-- Current Tripal cultivate information as a placeholder until we get the frontpage in place. -->
-            <div style="font-size:1.5em; line-height: 2em; margin-bottom: 100px; padding: 100px 100px;">
             <p>Tripal Cultivate is a collection of Tripal extension packages focused on providing intuitive data management support for breeding and pre-breeding activities to help you to</p>
-            <ul style="list-style: square outside none;">
+            <ul>
               <li>Diversify your crossing block with intuitive germplasm search form integrating passport, phenotypic and genotypic data.</li>
               <li>Streamline project management and easily incorporate pre-breeding data into your breeding workflow with a shared platform.</li>
               <ul>
@@ -111,7 +113,6 @@
               <li>Customize your site by introducing tech savvy staff to built-in administrative interfaces and a vast collection of pluggable themes (i.e. change styles) and modules (i.e. add functionality) provided by Drupal and Tripal international communities.</li>
               <li>Integrate new visualization and data analysis tools with less developer-time due to our extensive APIs and modular, open-source framework.</li>
             </ul>
-            </div>
 
 
           </div>

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -1,0 +1,135 @@
+{#
+/**
+ * @file
+ * Our themes implementation to display a single page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template normally located in the
+ * core/modules/system directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.highlighted: Items for the highlighted region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.content: The main content of the current page.
+ * - page.sidebar: Items for the first sidebar.
+ * - page.featured_bottom_first: Items for the first featured bottom region.
+ * - page.featured_bottom_second: Items for the second featured bottom region.
+ * - page.footer_first: Items for the first footer column.
+ * - page.footer_second: Items for the second footer column.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ * - page.social: Items for the social region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+
+<div id="page-wrapper" class="page-wrapper">
+  <div id="page" class="general-page">
+
+    {% if page.header or page.primary_menu or page.secondary_menu %}
+      <header id="header" class="site-header" data-drupal-selector="site-header" role="banner">
+
+        {# Gets fixed by JavaScript at wide widths. #}
+        <div class="site-header__fixable" data-drupal-selector="site-header-fixable">
+          <div class="site-header__initial">
+            <button class="sticky-header-toggle" data-drupal-selector="sticky-header-toggle" role="switch" aria-controls="site-header__inner" aria-label="{{ 'Sticky header'|t }}" aria-checked="false">
+              <span class="sticky-header-toggle__icon">
+                <span></span>
+                <span></span>
+                <span></span>
+              </span>
+            </button>
+          </div>
+
+          {# Needs to extend full width so box shadow will also extend. #}
+          <div id="site-header__inner" class="site-header__inner" data-drupal-selector="site-header-inner">
+            <div class="container site-header__inner__container">
+
+              {{ page.header }}
+
+              {% if page.primary_menu or page.secondary_menu %}
+                <div class="mobile-buttons" data-drupal-selector="mobile-buttons">
+                  <button class="mobile-nav-button" data-drupal-selector="mobile-nav-button" aria-label="{{ 'Main Menu'|t }}" aria-controls="header-nav" aria-expanded="false">
+                    <span class="mobile-nav-button__label">{{ 'Menu'|t }}</span>
+                    <span class="mobile-nav-button__icon"></span>
+                  </button>
+                </div>
+
+                <div id="header-nav" class="header-nav" data-drupal-selector="header-nav">
+                  {{ page.primary_menu }}
+                  {{ page.secondary_menu }}
+                </div>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      </header>
+    {% endif %}
+
+    <div id="main-wrapper" class="layout-main-wrapper layout-container">
+      <div id="main" class="layout-main">
+        <div class="main-content">
+          <a id="main-content" tabindex="-1"></a>
+          {{ page.hero }}
+          <div class="main-content__container container">
+            {{ page.highlighted }}
+            {{ page.breadcrumb }}
+
+            {% if page.sidebar %}
+              <div class="sidebar-grid grid-full">
+                <main role="main" class="site-main">
+                  {{ page.content_above }}
+                  {{ page.content }}
+                </main>
+
+                {{ page.sidebar }}
+              </div>
+            {% else %}
+              <main role="main">
+                {{ page.content_above }}
+                {{ page.content }}
+              </main>
+            {% endif %}
+            {{ page.content_below }}
+          </div>
+        </div>
+        <div class="social-bar">
+          {{ page.social }}
+        </div>
+      </div>
+    </div>
+
+    <footer class="site-footer">
+      <div class="site-footer__inner container">
+        {{ page.footer_top }}
+        {{ page.footer_bottom }}
+      </div>
+    </footer>
+
+    <div class="overlay" data-drupal-selector="overlay"></div>
+
+  </div>
+</div>

--- a/trpcultivatetheme.info.yml
+++ b/trpcultivatetheme.info.yml
@@ -6,6 +6,7 @@ package: Tripal Cultivate
 core_version_requirement: ^10
 libraries:
   - trpcultivatetheme/global
+  - trpcultivatetheme/frontpage
 regions:
   header: Header
   primary_menu: Primary menu

--- a/trpcultivatetheme.libraries.yml
+++ b/trpcultivatetheme.libraries.yml
@@ -22,3 +22,8 @@ global:
       css/layout/layout.css: {}
     theme:
       css/theme/print.css: { media: print }
+
+frontpage:
+  css:
+    theme:
+      css/layout/frontpage.css: {}


### PR DESCRIPTION
This PR ensures that 
- this theme is detecting templates
- adds the default template for the page from olivero
- adds a specific template for the frontpage based on the original page template
- adds a specific css library/file for themeing of the frontpage
- extends the docker environment for better theme development (sets twig debugging to true).

## Testing

Create a new docker on this branch
```
docker build --build-arg drupalversion=10.2.x-dev --build-arg phpversion=8.3 --tag=trpcultivate-theme:4x ./
docker run --publish=80:80 -tid --name=theme4x --volume=`pwd`:/var/www/drupal/web/themes/trpcultivatetheme trpcultivate-theme:4x
docker exec theme4x service postgresql restart
```

You should now see the following on the front page:
![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/1566301/978ae9fc-b2fa-4aa9-a0a8-9685846b3f7f)
