### PR TITLE
Header section

### DIFF
--- a/css/component/header.css
+++ b/css/component/header.css
@@ -22,26 +22,6 @@
 }
 
 /**
- * Header wrapping
- * Template: page.html.twig + page--front.html.twig
- */
-.tripalcultivate-theme-content-wrapper {
-  display: block;
-  margin: 0 auto;
-  position: relative;
-  width: 100%;
-}
-
-.tripalcultivate-theme-double-columns-wide {
-  align-items: center;
-  align-self: flex-start;
-  display: flex;
-  justify-content: space-between;
-  margin: 0;
-  padding: 0;
-}
-
-/**
  * Header System Branding Block
  * Template: block/block--system-branding-block.html.twig
  */
@@ -52,14 +32,12 @@
   padding: 0;
   margin: 0 0 0 10px;
 }
-
 .tripalcultivate-theme-banner-heading-subtext {
   color: #FFFFFF;
   display: block;
   font-weight: 300;
   font-size: 16px;
 }
-
 .tripalcultivate-theme-branding {
-  height: 180px;
+  height: auto;
 }

--- a/css/component/header.css
+++ b/css/component/header.css
@@ -20,3 +20,46 @@
 .site-header__inner .block-search-wide__button {
   color: var(--color--white);
 }
+
+/**
+ * Header wrapping
+ * Template: page.html.twig + page--front.html.twig
+ */
+.tripalcultivate-theme-content-wrapper {
+  display: block;
+  margin: 0 auto;
+  position: relative;
+  width: 100%;
+}
+
+.tripalcultivate-theme-double-columns-wide {
+  align-items: center;
+  align-self: flex-start;
+  display: flex;
+  justify-content: space-between;
+  margin: 0;
+  padding: 0;
+}
+
+/**
+ * Header System Branding Block
+ * Template: block/block--system-branding-block.html.twig
+ */
+.tripalcultivate-theme-banner-heading {
+  color: #FFFFFF;
+  font-size: 2.5em;
+  line-height: 0.7em;
+  padding: 0;
+  margin: 0 0 0 10px;
+}
+
+.tripalcultivate-theme-banner-heading-subtext {
+  color: #FFFFFF;
+  display: block;
+  font-weight: 300;
+  font-size: 16px;
+}
+
+.tripalcultivate-theme-branding {
+  height: 180px;
+}

--- a/css/layout/layout.css
+++ b/css/layout/layout.css
@@ -23,3 +23,22 @@
 .site-header__inner {
   padding-right: var(--content-left);
 }
+
+/**
+ * Global wrapping element.
+ * Template: page.html.twig + page--front.html.twig
+ */
+.tripalcultivate-theme-content-wrapper {
+  display: block;
+  margin: 0 auto;
+  position: relative;
+  width: 100%;
+}
+.tripalcultivate-theme-double-columns-wide {
+  align-items: center;
+  align-self: flex-start;
+  display: flex;
+  justify-content: space-between;
+  margin: 0;
+  padding: 0;
+}

--- a/templates/block/block--system-branding-block.html.twig
+++ b/templates/block/block--system-branding-block.html.twig
@@ -1,0 +1,32 @@
+{% extends "block.html.twig" %}
+{#
+/**
+ * @file
+ * Olivero's theme implementation for a branding block.
+ *
+ * Each branding element variable (logo, name, slogan) is only available if
+ * enabled in the block configuration.
+ *
+ * Available variables:
+ * - site_logo: Logo for site as defined in Appearance or theme settings.
+ * - site_name: Name for site as defined in Site information settings.
+ * - site_slogan: Slogan for site as defined in Site information settings.
+ */
+#}
+{% set attributes = attributes.addClass('site-branding') %}
+{% block content %}
+  <div class="site-branding__inner">
+    {% if site_logo %}
+      <a href="{{ path('<front>') }}" rel="home" class="site-branding__logo">
+        <img src="{{ site_logo }}" alt="{{ 'Home'|t }}" fetchpriority="high" />
+      </a>
+    {% endif %}
+    {% if site_name %}
+      <div class="site-branding__text">
+        <div class="site-branding__name">
+          <a href="{{ path('<front>') }}" title="{{ 'Home'|t }}" rel="home">{{ site_name }}</a>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/templates/block/block--system-branding-block.html.twig
+++ b/templates/block/block--system-branding-block.html.twig
@@ -15,18 +15,12 @@
 #}
 {% set attributes = attributes.addClass('site-branding') %}
 {% block content %}
-  <div class="site-branding__inner">
-    {% if site_logo %}
-      <a href="{{ path('<front>') }}" rel="home" class="site-branding__logo">
-        <img src="{{ site_logo }}" alt="{{ 'Home'|t }}" fetchpriority="high" />
-      </a>
-    {% endif %}
-    {% if site_name %}
-      <div class="site-branding__text">
-        <div class="site-branding__name">
-          <a href="{{ path('<front>') }}" title="{{ 'Home'|t }}" rel="home">{{ site_name }}</a>
-        </div>
-      </div>
-    {% endif %}
+  <!-- BRANDING: LEFT - logo -->
+  <div class="tripalcultivate-theme-double-columns-wide tripalcultivate-theme-branding">
+      <a href="#"><img src="{{ site_logo }}" alt="Logo" title="Logo"></a>
+      <h1 class="tripalcultivate-theme-banner-heading">
+          {{ site_name }}
+          <span class="tripalcultivate-theme-banner-heading-subtext">{{ site_slogan }}</span>
+      </h1>
   </div>
 {% endblock %}

--- a/templates/block/block--system-branding-block.html.twig
+++ b/templates/block/block--system-branding-block.html.twig
@@ -15,12 +15,16 @@
 #}
 {% set attributes = attributes.addClass('site-branding') %}
 {% block content %}
-  <!-- BRANDING: LEFT - logo -->
-  <div class="tripalcultivate-theme-double-columns-wide tripalcultivate-theme-branding">
-      <a href="#"><img src="{{ site_logo }}" alt="Logo" title="Logo"></a>
+  <div class="site-branding__inner">  
+    <!-- BRANDING: LEFT - logo, site name/title and slogan text -->
+    <div class="tripalcultivate-theme-double-columns-wide tripalcultivate-theme-branding">
+      <a href="{{ path('<front>') }}" rel="Home" class="site-branding__logo">
+        <img src="{{ site_logo }}" alt="{{ 'Home'|t }}">
+      </a>
       <h1 class="tripalcultivate-theme-banner-heading">
-          {{ site_name }}
-          <span class="tripalcultivate-theme-banner-heading-subtext">{{ site_slogan }}</span>
+        {{ site_name }}
+        <span class="tripalcultivate-theme-banner-heading-subtext">{{ site_slogan }}</span>
       </h1>
+    </div>
   </div>
 {% endblock %}

--- a/templates/layout/page--front.html.twig
+++ b/templates/layout/page--front.html.twig
@@ -71,21 +71,25 @@
           <div id="site-header__inner" class="site-header__inner" data-drupal-selector="site-header-inner">
             <div class="container site-header__inner__container">
 
-              {{ page.header }}
+              <div class="tripalcultivate-theme-content-wrapper">
+                <div class="tripalcultivate-theme-double-columns-wide">
+                  {{ page.header }}
 
-              {% if page.primary_menu or page.secondary_menu %}
-                <div class="mobile-buttons" data-drupal-selector="mobile-buttons">
-                  <button class="mobile-nav-button" data-drupal-selector="mobile-nav-button" aria-label="{{ 'Main Menu'|t }}" aria-controls="header-nav" aria-expanded="false">
-                    <span class="mobile-nav-button__label">{{ 'Menu'|t }}</span>
-                    <span class="mobile-nav-button__icon"></span>
-                  </button>
-                </div>
+                  {% if page.primary_menu or page.secondary_menu %}
+                    <div class="mobile-buttons" data-drupal-selector="mobile-buttons">
+                      <button class="mobile-nav-button" data-drupal-selector="mobile-nav-button" aria-label="{{ 'Main Menu'|t }}" aria-controls="header-nav" aria-expanded="false">
+                        <span class="mobile-nav-button__label">{{ 'Menu'|t }}</span>
+                        <span class="mobile-nav-button__icon"></span>
+                      </button>
+                    </div>
 
-                <div id="header-nav" class="header-nav" data-drupal-selector="header-nav">
-                  {{ page.primary_menu }}
-                  {{ page.secondary_menu }}
+                    <div id="header-nav" class="header-nav" data-drupal-selector="header-nav">
+                      {{ page.primary_menu }}
+                      {{ page.secondary_menu }}
+                    </div>
+                  {% endif %}
                 </div>
-              {% endif %}
+              </div>
             </div>
           </div>
         </div>

--- a/templates/layout/page--front.html.twig
+++ b/templates/layout/page--front.html.twig
@@ -70,9 +70,9 @@
           {# Needs to extend full width so box shadow will also extend. #}
           <div id="site-header__inner" class="site-header__inner" data-drupal-selector="site-header-inner">
             <div class="container site-header__inner__container">
-
               <div class="tripalcultivate-theme-content-wrapper">
                 <div class="tripalcultivate-theme-double-columns-wide">
+                  
                   {{ page.header }}
 
                   {% if page.primary_menu or page.secondary_menu %}

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -67,9 +67,9 @@
           {# Needs to extend full width so box shadow will also extend. #}
           <div id="site-header__inner" class="site-header__inner" data-drupal-selector="site-header-inner">
             <div class="container site-header__inner__container">
-
               <div class="tripalcultivate-theme-content-wrapper">
                 <div class="tripalcultivate-theme-double-columns-wide">
+                  
                   {{ page.header }}
 
                   {% if page.primary_menu or page.secondary_menu %}

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -68,21 +68,25 @@
           <div id="site-header__inner" class="site-header__inner" data-drupal-selector="site-header-inner">
             <div class="container site-header__inner__container">
 
-              {{ page.header }}
+              <div class="tripalcultivate-theme-content-wrapper">
+                <div class="tripalcultivate-theme-double-columns-wide">
+                  {{ page.header }}
 
-              {% if page.primary_menu or page.secondary_menu %}
-                <div class="mobile-buttons" data-drupal-selector="mobile-buttons">
-                  <button class="mobile-nav-button" data-drupal-selector="mobile-nav-button" aria-label="{{ 'Main Menu'|t }}" aria-controls="header-nav" aria-expanded="false">
-                    <span class="mobile-nav-button__label">{{ 'Menu'|t }}</span>
-                    <span class="mobile-nav-button__icon"></span>
-                  </button>
-                </div>
+                  {% if page.primary_menu or page.secondary_menu %}
+                    <div class="mobile-buttons" data-drupal-selector="mobile-buttons">
+                      <button class="mobile-nav-button" data-drupal-selector="mobile-nav-button" aria-label="{{ 'Main Menu'|t }}" aria-controls="header-nav" aria-expanded="false">
+                        <span class="mobile-nav-button__label">{{ 'Menu'|t }}</span>
+                        <span class="mobile-nav-button__icon"></span>
+                      </button>
+                    </div>
 
-                <div id="header-nav" class="header-nav" data-drupal-selector="header-nav">
-                  {{ page.primary_menu }}
-                  {{ page.secondary_menu }}
+                    <div id="header-nav" class="header-nav" data-drupal-selector="header-nav">
+                      {{ page.primary_menu }}
+                      {{ page.secondary_menu }}
+                    </div>
+                  {% endif %}
                 </div>
-              {% endif %}
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This PR contains updates to header section of the theme. Most of the changes are in the branding (logo, site name and slogan) elements in the header.

Changes made:
1. Moved css rules with global scope into css file containing global css rules.
2. Adjusted class name and added spaces to code to match the theme coding style.
3. Fixed header issue when collapsed during scroll.
![Screen Shot 2024-03-13 at 10 26 26 AM](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/21d519b7-1883-4deb-b49c-139241c02a1e)

To Test:
1. Launch a clone and set the default theme to TripalCultivate-Theme.
2. Edit Branding Block to add logo, site name and slogan text.
3. Save block, clear the cache and reload homepage.
4. Test collapsible header feature by scrolling down. Header should look similar to the image below.
![Screen Shot 2024-03-13 at 12 51 38 PM](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/ae4c2e1f-da53-4b58-9bf3-09a8b24d91a4)

Below is the logo used in this test:
![test-logo](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/718582b5-ecc4-4d81-9cf2-2401034e022c)

