### PR TITLE
Tile section regions

### DIFF
--- a/templates/block/block--trpcultivatetheme-tiles-banner-tall.html.twig
+++ b/templates/block/block--trpcultivatetheme-tiles-banner-tall.html.twig
@@ -1,0 +1,18 @@
+{#
+/**
+ * @file
+ * Tripal Cultivate Theme implementation for a banner tall tile block.
+ * Tiie section layout:
+ * _______________
+ * |      | X |__|
+ * |      |___|__|
+ * |______|______|
+ *
+ * Available variables:
+ * -
+ */
+#}
+
+<div class="tripalcultivate-theme-tiles-banner-tall">    
+  {{ content }}
+</div>

--- a/templates/block/block--trpcultivatetheme-tiles-banner-wide.html.twig
+++ b/templates/block/block--trpcultivatetheme-tiles-banner-wide.html.twig
@@ -1,0 +1,18 @@
+{#
+/**
+ * @file
+ * Tripal Cultivate Theme implementation for a banner wide tile block.
+ * Tiie section layout:
+ * _______________
+ * |      |   |__|
+ * |      |___|__|
+ * |______|__X___|
+ *
+ * Available variables:
+ * -
+ */
+#}
+
+<div class="tripalcultivate-theme-tiles-banner-wide">    
+  {{ content }}
+</div>

--- a/templates/block/block--trpcultivatetheme-tiles-large-half.html.twig
+++ b/templates/block/block--trpcultivatetheme-tiles-large-half.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Tripal Cultivate Theme implementation for a large half tile block.
+ *
+ * Available variables:
+ *
+ */
+#}
+
+<div class="tripalcultivate-theme-tiles-large-half">
+  {{ content }}
+</div>

--- a/templates/block/block--trpcultivatetheme-tiles-standard-bottom.html.twig
+++ b/templates/block/block--trpcultivatetheme-tiles-standard-bottom.html.twig
@@ -1,11 +1,11 @@
 {#
 /**
  * @file
- * Tripal Cultivate Theme implementation for a large half tile block.
+ * Tripal Cultivate Theme implementation for a standard bottom tile block.
  * Tiie section layout:
  * _______________
  * |      |   |__|
- * |  X   |___|__|
+ * |      |___|x_|
  * |______|______|
  *
  * Available variables:
@@ -13,6 +13,6 @@
  */
 #}
 
-<div class="tripalcultivate-theme-tiles-large-half">    
+<div class="tripalcultivate-theme-tiles-standard-bottom">    
   {{ content }}
 </div>

--- a/templates/block/block--trpcultivatetheme-tiles-standard-top.html.twig
+++ b/templates/block/block--trpcultivatetheme-tiles-standard-top.html.twig
@@ -1,0 +1,18 @@
+{#
+/**
+ * @file
+ * Tripal Cultivate Theme implementation for a standard top tile block.
+ * Tiie section layout:
+ * _______________
+ * |      |   |x_|
+ * |      |___|__|
+ * |______|______|
+ *
+ * Available variables:
+ * -
+ */
+#}
+
+<div class="tripalcultivate-theme-tiles-standard-top">    
+  {{ content }}
+</div>

--- a/templates/layout/page--front.html.twig
+++ b/templates/layout/page--front.html.twig
@@ -42,7 +42,16 @@
  * - page.social: Items for the social region.
  *
  * Tripal Cultivate Theme custom regions:
- * - page.trpcultivatetheme_tiles_large_half: Large half tile in the tiles section.
+ * Frontpage Top Tile Grid. Each region contains blocks and is themed via it's own template.
+ * ________________
+ * |      | B  |D_|
+ * |  A   |____|E_|
+ * |______|_C_____|
+ * - A) page.trpcultivatetheme_tiles_large_half
+ * - B) page.trpcultivatetheme_tiles_banner_tall
+ * - C) page.trpcultivatetheme_tiles_banner_wide
+ * - D) page.trpcultivatetheme_tiles_standard_top
+ * - E) page.trpcultivatetheme_tiles_standard_bottom
  *
  * @see template_preprocess_page()
  * @see html.html.twig

--- a/templates/layout/page--front.html.twig
+++ b/templates/layout/page--front.html.twig
@@ -118,6 +118,7 @@
                   {# This is first half positioned to the left (large half tile). #}
                   <div class="tripalcultivate-theme-tiles-half-column tripalcultivate-theme-tile-margin-right is-gray">
                     <div class="tripalcultivate-theme-tile-wrapper">
+                      {# Large Half Tile. #}
                       {{ page.trpcultivatetheme_tiles_large_half }}
                     </div>
                   </div>
@@ -128,20 +129,23 @@
                       <div class="tripalcultivate-theme-double-columns-wide">
                         <div class="tripalcultivate-theme-tiles-half-two-halves-column tripalcultivate-theme-tile-margin-right is-gray">
                           <div class="tripalcultivate-theme-tile-wrapper">
-                            Banner Style Tall Tile
+                            {# Banner Style Tall Tile. #}
+                            {{ page.trpcultivatetheme_tiles_banner_tall }}
                           </div>
                         </div>
 
                         <div class="tripalcultivate-theme-tiles-half-two-halves-column">
                           <div class="tripalcultivate-theme-tiles-half-standard tripalcultivate-theme-tile-margin-bottom is-gray">
                             <div class="tripalcultivate-theme-tile-wrapper">
-                              Standard Tile
+                              {# Standard Tile (TOP). #}
+                              {{ page.trpcultivatetheme_tiles_standard_top }}
                             </div>
                           </div>
 
                           <div class="tripalcultivate-theme-tiles-half-standard is-gray">
                             <div class="tripalcultivate-theme-tile-wrapper">
-                              Standard Tile
+                              {# Standard Tile (BOTTOM). #}
+                              {{ page.trpcultivatetheme_tiles_standard_bottom }}
                             </div>
                           </div>
                         </div>
@@ -150,7 +154,8 @@
 
                     <div class="tripalcultivate-theme-tiles-half-one-third-row is-gray">
                       <div class="tripalcultivate-theme-tile-wrapper">
-                        Banner Style Wide Tile
+                        {# Banner Style Wide Tile. #}
+                        {{ page.trpcultivatetheme_tiles_banner_wide }}
                       </div>
                     </div>
                   </div>

--- a/templates/layout/page--front.html.twig
+++ b/templates/layout/page--front.html.twig
@@ -41,6 +41,9 @@
  * - page.breadcrumb: Items for the breadcrumb region.
  * - page.social: Items for the social region.
  *
+ * Tripal Cultivate Theme custom regions:
+ * - page.trpcultivatetheme_tiles_large_half: Large half tile in the tiles section.
+ *
  * @see template_preprocess_page()
  * @see html.html.twig
  */
@@ -115,7 +118,7 @@
                   {# This is first half positioned to the left (large half tile). #}
                   <div class="tripalcultivate-theme-tiles-half-column tripalcultivate-theme-tile-margin-right is-gray">
                     <div class="tripalcultivate-theme-tile-wrapper">
-                      Large Half Tile
+                      {{ page.trpcultivatetheme_tiles_large_half }}
                     </div>
                   </div>
 

--- a/trpcultivatetheme.info.yml
+++ b/trpcultivatetheme.info.yml
@@ -23,4 +23,9 @@ regions:
   footer_top: Footer Top
   footer_bottom: Footer Bottom
   # Tripal Cultivate Theme Regions.
-  trpcultivatetheme_tiles_large_half: Tripal Cultivate Theme Tiles - Large Half
+  # Front page tile sections - Tile layout from left to right.
+  trpcultivatetheme_tiles_large_half:      Tripal Cultivate Theme Tiles - Large Half
+  trpcultivatetheme_tiles_banner_tall:     Tripal Cultivate Theme Tiles - Banner Style Tall
+  trpcultivatetheme_tiles_banner_wide:     Tripal Cultivate Theme Tiles - Banner Style Wide
+  trpcultivatetheme_tiles_standard_top:    Tripal Cultivate Theme Tiles - Standard Top
+  trpcultivatetheme_tiles_standard_bottom: Tripal Cultivate Theme Tiles - Standard Bottom

--- a/trpcultivatetheme.info.yml
+++ b/trpcultivatetheme.info.yml
@@ -22,4 +22,5 @@ regions:
   content_below: Content Below
   footer_top: Footer Top
   footer_bottom: Footer Bottom
-
+  # Tripal Cultivate Theme Regions.
+  trpcultivatetheme_tiles_large_half: Tripal Cultivate Theme Tiles - Large Half

--- a/trpcultivatetheme.theme
+++ b/trpcultivatetheme.theme
@@ -32,3 +32,35 @@ function trpcultivatetheme_preprocess_page(array &$variables): void {
 function trpcultivatetheme_preprocess_node(array &$variables): void {
 
 }
+
+/**
+ * Implement hook_theme_suggestions_HOOK_alter() for tiles section templates.
+ */
+function trpcultivatetheme_theme_suggestions_block_alter(&$suggestions, array $variables) {
+  if (!empty($variables['elements']['#id'])) {
+    /** @var \Drupal\block\BlockInterface $block */
+    $block = \Drupal::entityTypeManager()
+      ->getStorage('block')
+      ->load($variables['elements']['#id']);
+
+    if ($block) {
+      $region = $block
+        ->getRegion();
+
+      // Add tile content and markup into a tile region that uses the prefix
+      // trpcultivatetheme (module name) keyword.
+      $def_theme = \Drupal::config('system.theme')
+        ->get('default');
+      
+      $regions = system_region_list($def_theme);
+      foreach($regions as $region_name => $_) {
+        if (preg_match('/^trpcultivatetheme/', $region_name) && $region == $region_name) {
+          $suggestions[] = 'block__' . $region_name;
+          $suggestions[] = 'block__' . str_replace('_', '-', $region_name) . '__block';
+          $suggestions[] = 'block__' . $region_name . '__' . 'plugin_id' . '__' . $variables['elements']['#plugin_id'];
+          $suggestions[] = 'block__' . $region_name . '__' . 'id' . '__' . $variables['elements']['#id'];
+        }
+      }  
+    }  
+  }
+}

--- a/trpcultivatetheme.theme
+++ b/trpcultivatetheme.theme
@@ -34,7 +34,9 @@ function trpcultivatetheme_preprocess_node(array &$variables): void {
 }
 
 /**
- * Implement hook_theme_suggestions_HOOK_alter() for tiles section templates.
+ * Implement hook_theme_suggestions_block_alter() for tiles section templates.
+ *
+ * @see Olivero hook_theme_suggestions_block_alter implementation.
  */
 function trpcultivatetheme_theme_suggestions_block_alter(&$suggestions, array $variables) {
   if (!empty($variables['elements']['#id'])) {
@@ -48,13 +50,13 @@ function trpcultivatetheme_theme_suggestions_block_alter(&$suggestions, array $v
         ->getRegion();
 
       // Add tile content and markup into a tile region that uses the prefix
-      // trpcultivatetheme (module name) keyword.
+      // trpcultivatetheme (theme name) keyword only.
       $def_theme = \Drupal::config('system.theme')
         ->get('default');
-      
+            
       $regions = system_region_list($def_theme);
       foreach($regions as $region_name => $_) {
-        if (preg_match('/^trpcultivatetheme/', $region_name) && $region == $region_name) {
+        if (preg_match('/^' . $def_theme . '/', $region_name) && $region == $region_name) {
           $suggestions[] = 'block__' . $region_name;
           $suggestions[] = 'block__' . str_replace('_', '-', $region_name) . '__block';
           $suggestions[] = 'block__' . $region_name . '__' . 'plugin_id' . '__' . $variables['elements']['#plugin_id'];


### PR DESCRIPTION
This PR will create the content structure using blocks and regions. Inserting a content to individual tiles can be achieved using content block layout/type and content block.

![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/0eb944a6-41ce-409a-bf90-15f3b81afc5d)


To Test:
1. Launch a theme clone.
2. Switch to branch - tile-section-regions
3. Clear cache and reload the front page.
4. At this point, tiles are empty but the tile layout and form are visible.
5. Navigate to my site/admin/structure/block-content and add a block type (For Tiles in this example)
![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/29124216-ec49-4c7f-8cb4-b59393998ae1)
6. Navigate to my site/admin/content and click Blocks tab
7. Create a content by clicking on + Add content block button. Select the block type created in 5.
![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/d6234860-13cf-4ec9-8208-00e019250801)
8. Navigate to my site/admin/structure/block and scroll down to where the blocks for Tripal Cultivate Theme namely:
![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/f6395be0-d217-4d4a-add2-ba0aefa64325)
9. Select the block and click the button (place block) next to the title and locate the content created in 7 and click place block button
![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/d2edb0aa-0b17-440a-beb6-525d3bb28f2d)
10. Click Save Block and refresh front page.
 