### PR TITLE
Setup block types

### DIFF
--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.install
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.install
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @file
+ * Install, update, and uninstall functions for Tripal Cultivate Theme Companion.
+ */
+
+use Drupal\block_content\Entity\BlockContentType;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field\Entity\FieldConfig;
+
+/**
+ * Implements hook_enable().
+ * Create block content type and fields used by the tile layout in the theme companion.
+ */
+function trpcultivatetheme_companion_enable() {
+  // All content assets (field and storage) go into this bundle.
+  $tile_content = 'trpcultivatetheme_tile_block';
+
+  // Create the block type.
+  // @see admin/structure/block-content.
+  $tile_block = [
+    'id' => $tile_content,
+    'label' => 'Tripal Cultivate Theme Tile Block',
+    'description' => 'This block content type is used to insert content into tiles'
+  ];
+
+  BlockContentType::create($tile_block)
+    ->save();
+
+  // Tile fields schema:
+  $tile_fields = [
+    // Tile title text.
+    [
+      'field_name' => 'tripalcultivate_theme_tile_title',
+      'entity_type' => 'block_content',
+      'label' => 'Title Text',
+      'type' => 'text',
+      'settings' => [
+        'max_length' => 255
+      ]
+    ],
+
+    // Tile link.
+    // Tile link title.
+    // Tile cover image.
+    // Tile background colour.
+  ];
+ 
+  // Package block type, field and field storage.
+  foreach($tile_fields as $tile_field) {
+    // Create tile field storage:
+    FieldStorageConfig::create($tile_field)
+      ->save();
+    
+    // Attach field to the tile content block type.
+    $tile_field['bundle'] = $tile_content;
+    FieldConfig::create($tile_field)
+      ->save();
+  }
+}

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.install
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.install
@@ -12,17 +12,16 @@ use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\field\Entity\FieldConfig;
 
 /**
- * Implements hook_enable().
+ * Implements hook_install().
  * Create block content type and fields used by the tile layout in the theme companion.
  */
-function trpcultivatetheme_companion_enable() {
+function trpcultivatetheme_companion_install() {
   // All content assets (field and storage) go into this bundle.
   $tile_content = 'trpcultivatetheme_tile_block';
 
   // Tile field schema.
   // Field name length cannot be more than 32 chars (prefix is 23 chars).
-  // Field types:
-  // https://www.drupal.org/docs/drupal-apis/entity-api/fieldtypes-fieldwidgets-and-fieldformatters
+  // Field types: drupal.org/docs/drupal-apis/entity-api/fieldtypes-fieldwidgets-and-fieldformatters
   $field_prefix = 'trpcultivatetheme_tile_';
   $tile_fields = [
     // Tile title text.
@@ -83,6 +82,7 @@ function trpcultivatetheme_companion_enable() {
     ],
 
     // Additional fields here.
+    // NOTE the field name character limit.
   ];
   
 
@@ -117,7 +117,8 @@ function trpcultivatetheme_companion_enable() {
     // Create block type display configuration.
     // @see admin/structure/block-content - Manage Display tab.
     $tile_block_display_config = EntityViewDisplay::create($block_type);
-
+    
+    
     foreach($tile_fields as $field_name => $fieldprop) {
       // Create storage.
       FieldStorageConfig::create([
@@ -145,10 +146,12 @@ function trpcultivatetheme_companion_enable() {
         'settings' => $fieldprop['settings']
       ];
 
+      // Form:
       $field_setting['type'] = $fieldprop['type']['form'];
       $tile_block_form_config->setComponent($field_name, $field_setting)
         ->save();
 
+      // Display:
       $field_setting['type'] = $fieldprop['type']['display'];
       $tile_block_display_config->setComponent($field_name, $field_setting)
         ->save();

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.install
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.install
@@ -34,10 +34,13 @@ function trpcultivatetheme_companion_enable() {
         'display' => 'basic_string',
         'form' => 'string_textarea'
       ],
-      'settings' => ['max_length' => 255] 
+      'settings' => [
+        'placeholder' => 'eg. New Bioinformatics Tools Launch',
+        'max_length' => 255
+      ] 
     ],
     
-    // Tile link (url).
+    // Tile link (url) and text combo.
     $field_prefix . 'link' => [
       'label' => 'Tile Link (URL)',
       'weight' => 1,
@@ -51,41 +54,32 @@ function trpcultivatetheme_companion_enable() {
         'protocols' => ['http', 'https']
       ] 
     ],
-    
-    // Tile link text/title.
-    $field_prefix . 'linktext' => [
-      'label' => 'Tile Link Text',
-      'weight' => 2,
-      'type' => [
-        'storage' => 'string',
-        'display' => 'basic_string',
-        'form' => 'string_textfield'
-      ],
-      'settings' => ['max_length' => 100]
-    ],
 
     // Tile cover image.
     $field_prefix . 'coverimg' => [
-      'label' => 'Tile Cover Image (JPG, GIF or PNG)',
-      'weight' => 3,
+      'label' => 'Tile Cover Image (JPG, GIF, WEBP or PNG)',
+      'weight' => 2,
       'type' => [
         'storage' => 'image',
         'display' => 'file_uri',
         'form' => 'image_image'
       ],
-      'settings' => ['file_extensions' => 'jpg jpeg gif png']
+      'settings' => ['file_extensions' => 'jpg jpeg gif webp png']
     ],
 
     // Tile background colour.
     $field_prefix . 'bgcolor' => [
       'label' => 'Tile Background Colour',
-      'weight' => 4,
+      'weight' => 3,
       'type' => [
         'storage' => 'string',
         'display' => 'basic_string',
         'form' => 'string_textarea'
       ],
-      'settings' => ['max_length' => 7]
+      'settings' => [
+        'placeholder' => 'eg. #000000 for black',
+        'max_length' => 7
+      ]
     ],
 
     // Additional fields here.
@@ -148,6 +142,7 @@ function trpcultivatetheme_companion_enable() {
         'weight'  => $fieldprop['weight'],
         'hidden' => FALSE,
         'label' => 'hidden',
+        'settings' => $fieldprop['settings']
       ];
 
       $field_setting['type'] = $fieldprop['type']['form'];

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.install
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.install
@@ -6,6 +6,8 @@
  */
 
 use Drupal\block_content\Entity\BlockContentType;
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\Core\Entity\Entity\EntityViewDisplay;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\field\Entity\FieldConfig;
 
@@ -17,45 +19,144 @@ function trpcultivatetheme_companion_enable() {
   // All content assets (field and storage) go into this bundle.
   $tile_content = 'trpcultivatetheme_tile_block';
 
-  // Create the block type.
-  // @see admin/structure/block-content.
-  $tile_block = [
-    'id' => $tile_content,
-    'label' => 'Tripal Cultivate Theme Tile Block',
-    'description' => 'This block content type is used to insert content into tiles'
-  ];
-
-  BlockContentType::create($tile_block)
-    ->save();
-
-  // Tile fields schema:
+  // Tile field schema.
+  // Field name length cannot be more than 32 chars (prefix is 23 chars).
+  // Field types:
+  // https://www.drupal.org/docs/drupal-apis/entity-api/fieldtypes-fieldwidgets-and-fieldformatters
+  $field_prefix = 'trpcultivatetheme_tile_';
   $tile_fields = [
     // Tile title text.
-    [
-      'field_name' => 'tripalcultivate_theme_tile_title',
-      'entity_type' => 'block_content',
-      'label' => 'Title Text',
-      'type' => 'text',
+    $field_prefix . 'title' => [
+      'label' => 'Tile Title Text',
+      'weight' => 0,
+      'type' => [
+        'storage' => 'string',
+        'display' => 'basic_string',
+        'form' => 'string_textarea'
+      ],
+      'settings' => ['max_length' => 255] 
+    ],
+    
+    // Tile link (url).
+    $field_prefix . 'link' => [
+      'label' => 'Tile Link (URL)',
+      'weight' => 1,
+      'type' => [
+        'storage' => 'link',
+        'display' => 'uri_link', 
+        'form' => 'link_default'
+      ],
       'settings' => [
-        'max_length' => 255
-      ]
+        'link_type' => 'url',
+        'protocols' => ['http', 'https']
+      ] 
+    ],
+    
+    // Tile link text/title.
+    $field_prefix . 'linktext' => [
+      'label' => 'Tile Link Text',
+      'weight' => 2,
+      'type' => [
+        'storage' => 'string',
+        'display' => 'basic_string',
+        'form' => 'string_textfield'
+      ],
+      'settings' => ['max_length' => 100]
     ],
 
-    // Tile link.
-    // Tile link title.
     // Tile cover image.
+    $field_prefix . 'coverimg' => [
+      'label' => 'Tile Cover Image (JPG, GIF or PNG)',
+      'weight' => 3,
+      'type' => [
+        'storage' => 'image',
+        'display' => 'file_uri',
+        'form' => 'image_image'
+      ],
+      'settings' => ['file_extensions' => 'jpg jpeg gif png']
+    ],
+
     // Tile background colour.
+    $field_prefix . 'bgcolor' => [
+      'label' => 'Tile Background Colour',
+      'weight' => 4,
+      'type' => [
+        'storage' => 'string',
+        'display' => 'basic_string',
+        'form' => 'string_textarea'
+      ],
+      'settings' => ['max_length' => 7]
+    ],
+
+    // Additional fields here.
   ];
- 
-  // Package block type, field and field storage.
-  foreach($tile_fields as $tile_field) {
-    // Create tile field storage:
-    FieldStorageConfig::create($tile_field)
+  
+
+  // Prepare storage, containers and configuration for the field.
+
+  // Ensure that block type does not exists.
+  $block_exists = BlockContentType::load($tile_content);
+
+  if (!$block_exists) {
+    // Create the block type.
+    // @see admin/structure/block-content.
+    $tile_block = [
+      'id' => $tile_content,
+      'label' => 'Tripal Cultivate Theme Tile Block',
+      'description' => 'This block content type is used to insert content into tiles'
+    ];
+
+    BlockContentType::create($tile_block)
       ->save();
-    
-    // Attach field to the tile content block type.
-    $tile_field['bundle'] = $tile_content;
-    FieldConfig::create($tile_field)
-      ->save();
+
+    $block_type = [
+      'targetEntityType' => 'block_content',
+      'bundle'  => $tile_content,
+      'status' => TRUE,
+      'mode'  => 'default',
+    ];
+
+    // Create block form display configuration.
+    // @see admin/structure/block-content - Manage Form tab.
+    $tile_block_form_config = EntityFormDisplay::create($block_type); 
+
+    // Create block type display configuration.
+    // @see admin/structure/block-content - Manage Display tab.
+    $tile_block_display_config = EntityViewDisplay::create($block_type);
+
+    foreach($tile_fields as $field_name => $fieldprop) {
+      // Create storage.
+      FieldStorageConfig::create([
+        'field_name' => $field_name,
+        'entity_type' => 'block_content',
+        'type' => $fieldprop['type']['storage'],
+        'settings' => $fieldprop['settings']
+      ])
+        ->save();
+
+      // Attach to type.
+      FieldConfig::create([
+        'field_name' => $field_name,
+        'entity_type' => 'block_content',
+        'bundle' => $tile_content,
+        'label' => $fieldprop['label']
+      ])
+        ->save();
+
+      // Enable field.
+      $field_setting = [
+        'weight'  => $fieldprop['weight'],
+        'hidden' => FALSE,
+        'label' => 'hidden',
+      ];
+
+      $field_setting['type'] = $fieldprop['type']['form'];
+      $tile_block_form_config->setComponent($field_name, $field_setting)
+        ->save();
+
+      $field_setting['type'] = $fieldprop['type']['display'];
+      $tile_block_display_config->setComponent($field_name, $field_setting)
+        ->save();
+    }
   }
 }


### PR DESCRIPTION
This PR will setup tile block content type and create 4 fields required. The process is setup in the hook install of the companion module of the theme.

![Screen Shot 2024-04-02 at 10 42 30 AM](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/a57bc4c6-deef-46af-9185-c9e4b05dde7b)

NOTE: each tile content added is not rendered as mocked up (not themed) but note the following content items:
- A title
- A Link and a link text
- Cover image
- Hex code - background colour.

To test:
1. Clone repo and switch to branch setup-block-types (make sure to point repo to this branch to initiate install hook).
2. Build clone : ``` docker build --tag=trpcultivate:11 --build-arg drupalversion=10.2.x-dev --build-arg phpversion=8.3 ./ ```
3. Run a new container (no need to mount when confirming functionality): ```docker run --publish=80:80 -tid --name=theme11 trpcultivate:11 && docker exec theme11 service postgresql restart```
4. Setting up content requires administrator rights, login at this point.
5. Access my site/admin/structure/block and double check regions were created by the theme.
![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/97b1a965-cb96-437b-b432-357223bd628c)
6. Access my site/admin/structure/block-content and double check tile block content type was created by companion module.
![Screen Shot 2024-04-02 at 10 51 16 AM](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/0693aa72-d2cb-4ab4-bffd-2207d29b12b4)
7. Add tile content using Tripal Cultivate Theme Tile Block.
in my site/admin/content/block

![Screen Shot 2024-04-02 at 10 54 04 AM](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/f03b5d61-40ee-4abc-a38d-b88987d3e96f)

Content has a description field, use this field to identify content when placing it into a tile.

8. Place content into the regions in my site/admin/structure/block by clicking Place Block button.
9. Click save and refresh homepage. Repeat steps 7 and 8 as needed.


