### PR TITLE
Content region content type

### DIFF
--- a/trpcultivatetheme/css/layout/frontpage.css
+++ b/trpcultivatetheme/css/layout/frontpage.css
@@ -240,3 +240,18 @@
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.7);
   top: -14px;
 }
+
+.tripalcultivate-theme-content-articles .tripalcultivate-theme-tiles-half-column {
+  width: 48%;
+}
+
+.tripalcultivate-theme-content-articles article h4 {
+  margin-bottom: 10px;
+  margin-top: 0;
+}
+
+.tripalcultivate-theme-content-articles article p {
+  margin-top: 5px;
+  font-size: calc(var(--font-size-base) * 1.2);
+  line-height: 1.5em;
+}

--- a/trpcultivatetheme/templates/block/block--trpcultivatetheme-contents-main.html.twig
+++ b/trpcultivatetheme/templates/block/block--trpcultivatetheme-contents-main.html.twig
@@ -22,6 +22,26 @@
  *   </h3> 
  *   
  *   <div>
+ *     Theme content:
+ *     <div>
+ *       <div>
+ *         Article/content left.
+ *         <article>
+ *           <h4>Title</h4>
+ *           <p>Summary text</p>
+ *         </article>
+ *       </div>
+ *        
+ *       <div>
+ *         Article/content right.
+ *         <article>
+ *           <h4>Title</h4>
+ *           <p>Summary text</p>
+ *         </article>
+ *       </div>
+ *     </div>
+ *
+ *     Other content:
  *     Content/article
  *   </div>
  * </div>

--- a/trpcultivatetheme/templates/block/block--trpcultivatetheme-contents-main.html.twig
+++ b/trpcultivatetheme/templates/block/block--trpcultivatetheme-contents-main.html.twig
@@ -36,7 +36,21 @@
     </h3>
     
     <div>
-      {{ content }} 
+      {# If content has left and right article/text, theme content, otherwise load content. #}
+      {% if content.trpcultivatetheme_content_title1 and content.trpcultivatetheme_content_title1 %}
+        <div class="tripalcultivate-theme-double-columns-wide">
+          <div class="tripalcultivate-theme-tiles-half-column">
+            {{ content.trpcultivatetheme_content_title1 }}
+            {{ content.trpcultivatetheme_content_text1 }}
+          </div>
+          <div class="tripalcultivate-theme-tiles-half-column">
+            {{ content.trpcultivatetheme_content_title2 }}
+            {{ content.trpcultivatetheme_content_text2 }}
+          </div>
+        </div>
+      {% else %}
+        {{ content }}
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/trpcultivatetheme/templates/block/block--trpcultivatetheme-contents-main.html.twig
+++ b/trpcultivatetheme/templates/block/block--trpcultivatetheme-contents-main.html.twig
@@ -38,14 +38,18 @@
     <div>
       {# If content has left and right article/text, theme content, otherwise load content. #}
       {% if content.trpcultivatetheme_content_title1 and content.trpcultivatetheme_content_title1 %}
-        <div class="tripalcultivate-theme-double-columns-wide">
+        <div class="tripalcultivate-theme-double-columns-wide tripalcultivate-theme-content-articles">
           <div class="tripalcultivate-theme-tiles-half-column">
-            {{ content.trpcultivatetheme_content_title1 }}
-            {{ content.trpcultivatetheme_content_text1 }}
+            <article>  
+              <h4>{{ content.trpcultivatetheme_content_title1 }}</h4>
+              <p>{{ content.trpcultivatetheme_content_text1 }}</p>
+            </article> 
           </div>
           <div class="tripalcultivate-theme-tiles-half-column">
-            {{ content.trpcultivatetheme_content_title2 }}
-            {{ content.trpcultivatetheme_content_text2 }}
+            <article>
+              <h4>{{ content.trpcultivatetheme_content_title2 }}</h4>
+              <p>{{ content.trpcultivatetheme_content_text2 }}</p>
+            </article>
           </div>
         </div>
       {% else %}

--- a/trpcultivatetheme/trpcultivatetheme.theme
+++ b/trpcultivatetheme/trpcultivatetheme.theme
@@ -99,7 +99,7 @@ function trpcultivatetheme_preprocess_block(&$variables) {
         'title' => 'text',     // Tile title: text value.
         'link'  => 'link',     // Tile link: url + link text object.
         'coverimg' => 'image', // Tile cover image: image object.,
-        'bgcolor'  => 'color',  // Tile background color: text/string value.
+        'bgcolor'  => 'color', // Tile background color: text/string value.
       ];
 
       foreach($fields as $field_name => $field_type) {

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.install
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.install
@@ -76,11 +76,11 @@ function trpcultivatetheme_companion_install() {
       ],
     ],
 
-    // MAIN CONTENT:
-    'trpcultivatetheme_content_block' => [
+    // ARTICLE 2X - SIDE-BY-SIDE:
+    'trpcultivatetheme_art2x_block' => [
       'block' => [
-        'label' => 'Tripal Cultivate Theme Main Content Block',
-        'description' => 'This block content type is used to insert content into main content section'
+        'label' => 'Tripal Cultivate Theme Side-by-Side Article',
+        'description' => 'This block content type is used to insert 2 articles laid out side-by-side into the main content section'
       ],
       'fieldset' => [
         // LEFT Article.

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.install
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.install
@@ -83,6 +83,7 @@ function trpcultivatetheme_companion_install() {
         'description' => 'This block content type is used to insert content into main content section'
       ],
       'fieldset' => [
+        // LEFT Article.
         'trpcultivatetheme_content_title1' => [
           'label' => 'Left Article: Title Text',
           'weight' => 0,
@@ -94,6 +95,45 @@ function trpcultivatetheme_companion_install() {
           'settings' => [
             'placeholder' => 'eg. KnowPulse: A Web-Resource Focused on Diversity Data for Pulse Crop Improvement',
             'max_length' => 255
+          ]
+        ],
+        'trpcultivatetheme_content_text1' => [
+          'label' => 'Left Article: Summary Text',
+          'weight' => 1,
+          'type' => [
+            'storage' => 'text_long',
+            'display' => 'text_default',
+            'form' => 'text_textarea'
+          ],
+          'settings' => [
+            'rows' => 5
+          ]
+        ],
+
+        // RIGHT Article.
+        'trpcultivatetheme_content_title2' => [
+          'label' => 'Right Article: Title Text',
+          'weight' => 2,
+          'type' => [
+            'storage' => 'string',
+            'display' => 'basic_string',
+            'form' => 'string_textarea'
+          ],
+          'settings' => [
+            'placeholder' => 'eg. KnowPulse: A Web-Resource Focused on Diversity Data for Pulse Crop Improvement',
+            'max_length' => 255
+          ]
+        ],
+        'trpcultivatetheme_content_text2' => [
+          'label' => 'Right Article: Summary Text',
+          'weight' => 3,
+          'type' => [
+            'storage' => 'text_long',
+            'display' => 'text_default',
+            'form' => 'text_textarea'
+          ],
+          'settings' => [
+            'rows' => 5
           ]
         ],
       ],
@@ -125,11 +165,11 @@ function trpcultivatetheme_companion_install() {
       
       // Create block form display configuration.
       // @see admin/structure/block-content - Manage Form tab.
-      $tile_block_form_config = EntityFormDisplay::create($block_type); 
+      $block_form_config = EntityFormDisplay::create($block_type); 
 
       // Create block type display configuration.
       // @see admin/structure/block-content - Manage Display tab.
-      $tile_block_display_config = EntityViewDisplay::create($block_type);
+      $block_display_config = EntityViewDisplay::create($block_type);
       
       foreach($schema['fieldset'] as $field_name => $field_prop) {
         // Create storage.
@@ -160,16 +200,16 @@ function trpcultivatetheme_companion_install() {
 
         // Form:
         $field_setting['type'] = $field_prop['type']['form'];
-        $tile_block_form_config->setComponent($field_name, $field_setting)
+        $block_form_config->setComponent($field_name, $field_setting)
           ->save();
 
         // Display:
         $field_setting['type'] = $field_prop['type']['display'];
-        $tile_block_display_config->setComponent($field_name, $field_setting)
+        $block_display_config->setComponent($field_name, $field_setting)
           ->save();
-
-        unset($tile_block_form_config, $tile_block_display_config);
       }
+
+      unset($block_form_config, $block_display_config);
     }
   }
 }

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.install
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.install
@@ -16,145 +16,160 @@ use Drupal\field\Entity\FieldConfig;
  * Create block content type and fields used by the tile layout in the theme companion.
  */
 function trpcultivatetheme_companion_install() {
-  // All content assets (field and storage) go into this bundle.
-  $tile_content = 'trpcultivatetheme_tile_block';
-
-  // Tile field schema.
-  // Field name length cannot be more than 32 chars (prefix is 23 chars).
-  // Field types: drupal.org/docs/drupal-apis/entity-api/fieldtypes-fieldwidgets-and-fieldformatters
-  $field_prefix = 'trpcultivatetheme_tile_';
-  $tile_fields = [
-    // Tile title text.
-    $field_prefix . 'title' => [
-      'label' => 'Tile Title Text',
-      'weight' => 0,
-      'type' => [
-        'storage' => 'string',
-        'display' => 'basic_string',
-        'form' => 'string_textarea'
+  $content_schema = [
+    // TILES:
+    'trpcultivatetheme_tile_block' => [
+      'block' => [
+        'label' => 'Tripal Cultivate Theme Tile Block',
+        'description' => 'This block content type is used to insert content into tiles'
       ],
-      'settings' => [
-        'placeholder' => 'eg. New Bioinformatics Tools Launch',
-        'max_length' => 255
-      ] 
-    ],
-    
-    // Tile link (url) and text combo.
-    $field_prefix . 'link' => [
-      'label' => 'Tile Link (URL)',
-      'weight' => 1,
-      'type' => [
-        'storage' => 'link',
-        'display' => 'uri_link', 
-        'form' => 'link_default'
+      'fieldset' => [
+        'trpcultivatetheme_tile_title'    => [
+          'label' => 'Tile Title Text',
+          'weight' => 0,
+          'type' => [
+            'storage' => 'string',
+            'display' => 'basic_string',
+            'form' => 'string_textarea'
+          ],
+          'settings' => [
+            'placeholder' => 'eg. New Bioinformatics Tools Launch',
+            'max_length' => 255
+          ]
+        ],
+        'trpcultivatetheme_tile_link'     => [
+          'label' => 'Tile Link (URL)',
+          'weight' => 1,
+          'type' => [
+            'storage' => 'link',
+            'display' => 'uri_link', 
+            'form' => 'link_default'
+          ],
+          'settings' => [
+            'link_type' => 'url',
+            'protocols' => ['http', 'https']
+          ] 
+        ],
+        'trpcultivatetheme_tile_coverimg' => [
+          'label' => 'Tile Cover Image (JPG, GIF, WEBP or PNG)',
+          'weight' => 2,
+          'type' => [
+            'storage' => 'image',
+            'display' => 'file_uri',
+            'form' => 'image_image'
+          ],
+          'settings' => ['file_extensions' => 'jpg jpeg gif webp png']  
+        ],
+        'trpcultivatetheme_tile_bgcolor'  => [
+          'label' => 'Tile Background Colour',
+          'weight' => 3,
+          'type' => [
+            'storage' => 'string',
+            'display' => 'basic_string',
+            'form' => 'string_textarea'
+          ],
+          'settings' => [
+            'placeholder' => 'eg. #000000 for black',
+            'max_length' => 7
+          ] 
+        ],
       ],
-      'settings' => [
-        'link_type' => 'url',
-        'protocols' => ['http', 'https']
-      ] 
-    ],
-
-    // Tile cover image.
-    $field_prefix . 'coverimg' => [
-      'label' => 'Tile Cover Image (JPG, GIF, WEBP or PNG)',
-      'weight' => 2,
-      'type' => [
-        'storage' => 'image',
-        'display' => 'file_uri',
-        'form' => 'image_image'
-      ],
-      'settings' => ['file_extensions' => 'jpg jpeg gif webp png']
-    ],
-
-    // Tile background colour.
-    $field_prefix . 'bgcolor' => [
-      'label' => 'Tile Background Colour',
-      'weight' => 3,
-      'type' => [
-        'storage' => 'string',
-        'display' => 'basic_string',
-        'form' => 'string_textarea'
-      ],
-      'settings' => [
-        'placeholder' => 'eg. #000000 for black',
-        'max_length' => 7
-      ]
     ],
 
-    // Additional fields here.
-    // NOTE the field name character limit.
+    // MAIN CONTENT:
+    'trpcultivatetheme_content_block' => [
+      'block' => [
+        'label' => 'Tripal Cultivate Theme Main Content Block',
+        'description' => 'This block content type is used to insert content into main content section'
+      ],
+      'fieldset' => [
+        'trpcultivatetheme_content_title1' => [
+          'label' => 'Left Article: Title Text',
+          'weight' => 0,
+          'type' => [
+            'storage' => 'string',
+            'display' => 'basic_string',
+            'form' => 'string_textarea'
+          ],
+          'settings' => [
+            'placeholder' => 'eg. KnowPulse: A Web-Resource Focused on Diversity Data for Pulse Crop Improvement',
+            'max_length' => 255
+          ]
+        ],
+      ],
+    ],
   ];
   
+  // Create content block.
+  foreach ($content_schema as $bundle => $schema) {
+    // All content assets (field and storage) go into this bundle.
+    // Prepare storage, containers and configuration for the field.
 
-  // Prepare storage, containers and configuration for the field.
-
-  // Ensure that block type does not exists.
-  $block_exists = BlockContentType::load($tile_content);
-
-  if (!$block_exists) {
-    // Create the block type.
-    // @see admin/structure/block-content.
-    $tile_block = [
-      'id' => $tile_content,
-      'label' => 'Tripal Cultivate Theme Tile Block',
-      'description' => 'This block content type is used to insert content into tiles'
-    ];
-
-    BlockContentType::create($tile_block)
-      ->save();
-
-    $block_type = [
-      'targetEntityType' => 'block_content',
-      'bundle'  => $tile_content,
-      'status' => TRUE,
-      'mode'  => 'default',
-    ];
-
-    // Create block form display configuration.
-    // @see admin/structure/block-content - Manage Form tab.
-    $tile_block_form_config = EntityFormDisplay::create($block_type); 
-
-    // Create block type display configuration.
-    // @see admin/structure/block-content - Manage Display tab.
-    $tile_block_display_config = EntityViewDisplay::create($block_type);
+    // Ensure that block type does not exists.
+    $block_exists = BlockContentType::load($bundle);
     
-    
-    foreach($tile_fields as $field_name => $fieldprop) {
-      // Create storage.
-      FieldStorageConfig::create([
-        'field_name' => $field_name,
-        'entity_type' => 'block_content',
-        'type' => $fieldprop['type']['storage'],
-        'settings' => $fieldprop['settings']
-      ])
+    if (!$block_exists) {
+      // Create the block type.
+      // @see admin/structure/block-content.
+      $block = $schema['block'] + ['id' => $bundle]; 
+
+      BlockContentType::create($block)
         ->save();
 
-      // Attach to type.
-      FieldConfig::create([
-        'field_name' => $field_name,
-        'entity_type' => 'block_content',
-        'bundle' => $tile_content,
-        'label' => $fieldprop['label']
-      ])
-        ->save();
-
-      // Enable field.
-      $field_setting = [
-        'weight'  => $fieldprop['weight'],
-        'hidden' => FALSE,
-        'label' => 'hidden',
-        'settings' => $fieldprop['settings']
+      $block_type = [
+        'targetEntityType' => 'block_content',
+        'bundle'  => $bundle,
+        'status' => TRUE,
+        'mode'  => 'default',
       ];
+      
+      // Create block form display configuration.
+      // @see admin/structure/block-content - Manage Form tab.
+      $tile_block_form_config = EntityFormDisplay::create($block_type); 
 
-      // Form:
-      $field_setting['type'] = $fieldprop['type']['form'];
-      $tile_block_form_config->setComponent($field_name, $field_setting)
-        ->save();
+      // Create block type display configuration.
+      // @see admin/structure/block-content - Manage Display tab.
+      $tile_block_display_config = EntityViewDisplay::create($block_type);
+      
+      foreach($schema['fieldset'] as $field_name => $field_prop) {
+        // Create storage.
+        FieldStorageConfig::create([
+          'field_name' => $field_name,
+          'entity_type' => 'block_content',
+          'type' => $field_prop['type']['storage'],
+          'settings' => $field_prop['settings']
+        ])
+          ->save();
 
-      // Display:
-      $field_setting['type'] = $fieldprop['type']['display'];
-      $tile_block_display_config->setComponent($field_name, $field_setting)
-        ->save();
+        // Attach to type.
+        FieldConfig::create([
+          'field_name' => $field_name,
+          'entity_type' => 'block_content',
+          'bundle' => $bundle,
+          'label' => $field_prop['label']
+        ])
+          ->save();
+
+        // Enable field.
+        $field_setting = [
+          'weight'  => $field_prop['weight'],
+          'hidden' => FALSE,
+          'label' => 'hidden',
+          'settings' => $field_prop['settings']
+        ];
+
+        // Form:
+        $field_setting['type'] = $field_prop['type']['form'];
+        $tile_block_form_config->setComponent($field_name, $field_setting)
+          ->save();
+
+        // Display:
+        $field_setting['type'] = $field_prop['type']['display'];
+        $tile_block_display_config->setComponent($field_name, $field_setting)
+          ->save();
+
+        unset($tile_block_form_config, $tile_block_display_config);
+      }
     }
   }
 }

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.module
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.module
@@ -65,15 +65,15 @@ function trpcultivatetheme_companion_block_access(Block $block, $operation, Acco
       
       // Tile block content has content key in block dependencies (#dependencies) object,
       // test if block had content and if content was of type tile block.
-      if (isset($block_dependencies['content'][0])) {
-        // No content.
-        $is_not_tile = TRUE;
-      }
-      else {
+      if (isset($block_dependencies['content'])) {
         // Has content.
         if (!str_contains($block_dependencies['content'][0], 'trpcultivatetheme_tile_block')) {
           $is_not_tile = TRUE;
         }
+      }
+      else {
+        // No content.
+        $is_not_tile = TRUE;
       }
 
       if ($is_not_tile) {

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.module
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.module
@@ -39,7 +39,7 @@ function trpcultivatetheme_companion_block_access(Block $block, $operation, Acco
   $regions = system_region_list($def_theme);
   
   // Extract only the trpcultivatetheme_tiles custom regions.
-  $trpcultivatetheme_tiles_regions = []; 
+  $trpcultivatetheme_tiles_regions = [];
   
   foreach($regions as $region_name => $_) {
     if (preg_match('/^' . $def_theme . '_tiles/', $region_name)) {
@@ -59,14 +59,24 @@ function trpcultivatetheme_companion_block_access(Block $block, $operation, Acco
     if ($block_id) {
       // @debug dpm($block);
 
-      // Tile content is a block content type and id is a hash value
-      // ie. block_content:58dad12f-a9e4-4305-a082-d370ae079137.
-      // @see hook_install().
-      // Content is block_content plus unique id number since multiple instance can be created.
-    
-      if (!preg_match('/^block_content:/', $block_id)) {  
-        // The content id does not match the tripalcultivatetheme tile content id format.
-        
+      // Ensure that only tile block contents get processed.
+      $block_dependencies = $block->getDependencies();
+      $is_not_tile = FALSE;
+      
+      // Tile block content has content key in block dependencies (#dependencies) object,
+      // test if block had content and if content was of type tile block.
+      if (isset($block_dependencies['content'][0])) {
+        // No content.
+        $is_not_tile = TRUE;
+      }
+      else {
+        // Has content.
+        if (!str_contains($block_dependencies['content'][0], 'trpcultivatetheme_tile_block')) {
+          $is_not_tile = TRUE;
+        }
+      }
+
+      if ($is_not_tile) {
         $error_message = 'A non-compatible content was added to Tripal Cultivate Theme Tiles region. ';
         $error_message .= 'BLOCK: '. ucwords(str_replace('_', ' ', $block_id)) . ' REGION: ' . ucwords(str_replace('_', ' ', $block_region));
 


### PR DESCRIPTION
This PR add a custom block content type that will allow for contents to be placed in the main content region and themed as shown in the screenshot below.

![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/93f995ef-4d2d-4f53-9205-501c3b2c5a62)


**To Test:**

Upon install, the the companion module will create a content block type: Tripal Cultivate Theme Main Content Block  
![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/b8b93e8e-fe4a-4653-9ad9-1bcd5b70ff3f)

Click link to load form entry. The form will require 2 articles which will be laid out side by side in the main content area. Content body supports image upload in the same field where content summary text is entered.

Adjust image placement by clicking the image and select image positioning.

![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/ba9982a0-8ed4-4358-9d27-3413bb0432db)

Repeat steps for the the other article/content.

