### PR TITLE
Footer section

### DIFF
--- a/trpcultivatetheme/css/layout/frontpage.css
+++ b/trpcultivatetheme/css/layout/frontpage.css
@@ -280,7 +280,7 @@
 }
 
 .tripalcultivate-theme-content-funder {
-  height: 60px;
+  height: 125px;
   display: inline-block;
   width: fit-content;
 }

--- a/trpcultivatetheme/css/layout/frontpage.css
+++ b/trpcultivatetheme/css/layout/frontpage.css
@@ -240,3 +240,18 @@
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.7);
   top: -14px;
 }
+
+.tripalcultivate-theme-content-articles .tripalcultivate-theme-tiles-half-column {
+  width: 48%;
+}
+
+.tripalcultivate-theme-content-articles article h4 {
+  margin-bottom: 10px;
+  margin-top: 0;
+}
+
+.tripalcultivate-theme-content-articles article p {
+  margin-top: 5px;
+  font-size: calc(var(--font-size-base) * 1.2);
+  line-height: 1.5em;
+}

--- a/trpcultivatetheme/css/layout/frontpage.css
+++ b/trpcultivatetheme/css/layout/frontpage.css
@@ -240,3 +240,21 @@
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.7);
   top: -14px;
 }
+
+/* Funders */
+#tripalcultivate-theme-funders > div {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 20px 0 0 0;
+}
+
+#tripalcultivate-theme-funders h4 {
+  color: #C0C0C0;
+  text-align: center;
+  margin-bottom: 10px;
+}
+
+#tripalcultivate-theme-funders > div div {
+  flex: 1 0 auto;
+  margin: var(--tile-margin-width);
+}

--- a/trpcultivatetheme/css/layout/frontpage.css
+++ b/trpcultivatetheme/css/layout/frontpage.css
@@ -257,6 +257,10 @@
 }
 
 /* Funders */
+#tripalcultivate-theme-funders {
+  text-align: center;
+}
+
 #tripalcultivate-theme-funders > div {
   display: flex;
   flex-wrap: wrap;
@@ -272,4 +276,17 @@
 #tripalcultivate-theme-funders > div div {
   flex: 1 0 auto;
   margin: var(--tile-margin-width);
+  padding: 0;
+}
+
+.tripalcultivate-theme-content-funder {
+  height: 60px;
+  display: inline-block;
+  width: fit-content;
+}
+
+.tripalcultivate-theme-content-funder img {
+  width: 90%;
+  height: 100%;
+  object-fit:contain;
 }

--- a/trpcultivatetheme/templates/block/block--trpcultivatetheme-contents-funders.html.twig
+++ b/trpcultivatetheme/templates/block/block--trpcultivatetheme-contents-funders.html.twig
@@ -1,0 +1,24 @@
+{% extends "block.html.twig" %}
+{#
+/**
+ * @file
+ * Tripal Cultivate Theme implementation for funders content.
+ *
+ * Available variables:
+ *
+ * Content layout:
+ */
+#}
+
+{% block content %}
+  {% set link = content.trpcultivatetheme_funders_link ? content.trpcultivatetheme_funders_link|render|striptags : '' %}
+  {% set logo = content.trpcultivatetheme_funders_logo['#items'].entity.uri.value ? file_url(content.trpcultivatetheme_funders_logo['#items'].entity.uri.value) : '' %}
+  
+  {% if link and logo %}
+  <div class="tripalcultivate-theme-content-funder">
+    <a href="{{ link }}" target="_blank">
+      <img src="{{ logo }}" />
+    </a>
+  </div>
+  {% endif %}
+{% endblock %}

--- a/trpcultivatetheme/templates/block/block--trpcultivatetheme-contents-main.html.twig
+++ b/trpcultivatetheme/templates/block/block--trpcultivatetheme-contents-main.html.twig
@@ -22,6 +22,26 @@
  *   </h3> 
  *   
  *   <div>
+ *     Theme content:
+ *     <div>
+ *       <div>
+ *         Article/content left.
+ *         <article>
+ *           <h4>Title</h4>
+ *           <p>Summary text</p>
+ *         </article>
+ *       </div>
+ *        
+ *       <div>
+ *         Article/content right.
+ *         <article>
+ *           <h4>Title</h4>
+ *           <p>Summary text</p>
+ *         </article>
+ *       </div>
+ *     </div>
+ *
+ *     Other content:
  *     Content/article
  *   </div>
  * </div>

--- a/trpcultivatetheme/templates/block/block--trpcultivatetheme-contents-main.html.twig
+++ b/trpcultivatetheme/templates/block/block--trpcultivatetheme-contents-main.html.twig
@@ -36,7 +36,21 @@
     </h3>
     
     <div>
-      {{ content }} 
+      {# If content has left and right article/text, theme content, otherwise load content. #}
+      {% if content.trpcultivatetheme_content_title1 and content.trpcultivatetheme_content_title1 %}
+        <div class="tripalcultivate-theme-double-columns-wide">
+          <div class="tripalcultivate-theme-tiles-half-column">
+            {{ content.trpcultivatetheme_content_title1 }}
+            {{ content.trpcultivatetheme_content_text1 }}
+          </div>
+          <div class="tripalcultivate-theme-tiles-half-column">
+            {{ content.trpcultivatetheme_content_title2 }}
+            {{ content.trpcultivatetheme_content_text2 }}
+          </div>
+        </div>
+      {% else %}
+        {{ content }}
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/trpcultivatetheme/templates/block/block--trpcultivatetheme-contents-main.html.twig
+++ b/trpcultivatetheme/templates/block/block--trpcultivatetheme-contents-main.html.twig
@@ -38,14 +38,18 @@
     <div>
       {# If content has left and right article/text, theme content, otherwise load content. #}
       {% if content.trpcultivatetheme_content_title1 and content.trpcultivatetheme_content_title1 %}
-        <div class="tripalcultivate-theme-double-columns-wide">
+        <div class="tripalcultivate-theme-double-columns-wide tripalcultivate-theme-content-articles">
           <div class="tripalcultivate-theme-tiles-half-column">
-            {{ content.trpcultivatetheme_content_title1 }}
-            {{ content.trpcultivatetheme_content_text1 }}
+            <article>  
+              <h4>{{ content.trpcultivatetheme_content_title1 }}</h4>
+              <p>{{ content.trpcultivatetheme_content_text1 }}</p>
+            </article> 
           </div>
           <div class="tripalcultivate-theme-tiles-half-column">
-            {{ content.trpcultivatetheme_content_title2 }}
-            {{ content.trpcultivatetheme_content_text2 }}
+            <article>
+              <h4>{{ content.trpcultivatetheme_content_title2 }}</h4>
+              <p>{{ content.trpcultivatetheme_content_text2 }}</p>
+            </article>
           </div>
         </div>
       {% else %}

--- a/trpcultivatetheme/templates/layout/page--front.html.twig
+++ b/trpcultivatetheme/templates/layout/page--front.html.twig
@@ -178,7 +178,15 @@
             <div id="tripalcultivate-theme-contents">
               {# Main Content Region #}
               {{ page.trpcultivatetheme_contents_main }}
-            </div>  
+            </div>
+
+            <div id="tripalcultivate-theme-funders">
+              {# Funders Region #}
+              {% if page.trpcultivatetheme_contents_funders is iterable %}
+                <h4>This project is made possible by the invaluable support of our funders</h4>
+                {{ page.trpcultivatetheme_contents_funders }}
+              {% endif %}
+            </div>              
           </div>
         </div>
         <div class="social-bar">

--- a/trpcultivatetheme/templates/layout/page--front.html.twig
+++ b/trpcultivatetheme/templates/layout/page--front.html.twig
@@ -182,7 +182,7 @@
 
             <div id="tripalcultivate-theme-funders">
               {# Funders Region #}
-              {% if page.trpcultivatetheme_contents_funders is iterable %}
+              {% if page.trpcultivatetheme_contents_funders %}
                 <h4>This project is made possible by the invaluable support of our funders</h4>
                 {{ page.trpcultivatetheme_contents_funders }}
               {% endif %}

--- a/trpcultivatetheme/trpcultivatetheme.info.yml
+++ b/trpcultivatetheme/trpcultivatetheme.info.yml
@@ -33,3 +33,5 @@ regions:
   trpcultivatetheme_tiles_standard_bottom: Tripal Cultivate Theme Tiles - Standard Bottom
   # Front page content section.
   trpcultivatetheme_contents_main:  Tripal Cultivate Theme Content - Main Content Section
+  # Front page content funders section.
+  trpcultivatetheme_contents_funders: Tripal Cultivate Theme Content - Funders Section

--- a/trpcultivatetheme/trpcultivatetheme.theme
+++ b/trpcultivatetheme/trpcultivatetheme.theme
@@ -99,7 +99,7 @@ function trpcultivatetheme_preprocess_block(&$variables) {
         'title' => 'text',     // Tile title: text value.
         'link'  => 'link',     // Tile link: url + link text object.
         'coverimg' => 'image', // Tile cover image: image object.,
-        'bgcolor'  => 'color',  // Tile background color: text/string value.
+        'bgcolor'  => 'color', // Tile background color: text/string value.
       ];
 
       foreach($fields as $field_name => $field_type) {

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.install
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.install
@@ -76,11 +76,11 @@ function trpcultivatetheme_companion_install() {
       ],
     ],
 
-    // MAIN CONTENT:
-    'trpcultivatetheme_content_block' => [
+    // ARTICLE 2X - SIDE-BY-SIDE:
+    'trpcultivatetheme_art2x_block' => [
       'block' => [
-        'label' => 'Tripal Cultivate Theme Main Content Block',
-        'description' => 'This block content type is used to insert content into main content section'
+        'label' => 'Tripal Cultivate Theme Side-by-Side Article',
+        'description' => 'This block content type is used to insert 2 articles laid out side-by-side into the main content section'
       ],
       'fieldset' => [
         // LEFT Article.

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.install
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.install
@@ -140,7 +140,7 @@ function trpcultivatetheme_companion_install() {
     ],
 
     // FUNDER LOGO:
-    'trpcultivatetheme_content_block' => [
+    'trpcultivatetheme_funder_block' => [
       'block' => [
         'label' => 'Tripal Cultivate Theme Funder Content Block',
         'description' => 'This block content type is used to insert a funder into funders section'

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.install
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.install
@@ -83,6 +83,7 @@ function trpcultivatetheme_companion_install() {
         'description' => 'This block content type is used to insert content into main content section'
       ],
       'fieldset' => [
+        // LEFT Article.
         'trpcultivatetheme_content_title1' => [
           'label' => 'Left Article: Title Text',
           'weight' => 0,
@@ -94,6 +95,45 @@ function trpcultivatetheme_companion_install() {
           'settings' => [
             'placeholder' => 'eg. KnowPulse: A Web-Resource Focused on Diversity Data for Pulse Crop Improvement',
             'max_length' => 255
+          ]
+        ],
+        'trpcultivatetheme_content_text1' => [
+          'label' => 'Left Article: Summary Text',
+          'weight' => 1,
+          'type' => [
+            'storage' => 'text_long',
+            'display' => 'text_default',
+            'form' => 'text_textarea'
+          ],
+          'settings' => [
+            'rows' => 5
+          ]
+        ],
+
+        // RIGHT Article.
+        'trpcultivatetheme_content_title2' => [
+          'label' => 'Right Article: Title Text',
+          'weight' => 2,
+          'type' => [
+            'storage' => 'string',
+            'display' => 'basic_string',
+            'form' => 'string_textarea'
+          ],
+          'settings' => [
+            'placeholder' => 'eg. KnowPulse: A Web-Resource Focused on Diversity Data for Pulse Crop Improvement',
+            'max_length' => 255
+          ]
+        ],
+        'trpcultivatetheme_content_text2' => [
+          'label' => 'Right Article: Summary Text',
+          'weight' => 3,
+          'type' => [
+            'storage' => 'text_long',
+            'display' => 'text_default',
+            'form' => 'text_textarea'
+          ],
+          'settings' => [
+            'rows' => 5
           ]
         ],
       ],
@@ -125,11 +165,11 @@ function trpcultivatetheme_companion_install() {
       
       // Create block form display configuration.
       // @see admin/structure/block-content - Manage Form tab.
-      $tile_block_form_config = EntityFormDisplay::create($block_type); 
+      $block_form_config = EntityFormDisplay::create($block_type); 
 
       // Create block type display configuration.
       // @see admin/structure/block-content - Manage Display tab.
-      $tile_block_display_config = EntityViewDisplay::create($block_type);
+      $block_display_config = EntityViewDisplay::create($block_type);
       
       foreach($schema['fieldset'] as $field_name => $field_prop) {
         // Create storage.
@@ -160,16 +200,16 @@ function trpcultivatetheme_companion_install() {
 
         // Form:
         $field_setting['type'] = $field_prop['type']['form'];
-        $tile_block_form_config->setComponent($field_name, $field_setting)
+        $block_form_config->setComponent($field_name, $field_setting)
           ->save();
 
         // Display:
         $field_setting['type'] = $field_prop['type']['display'];
-        $tile_block_display_config->setComponent($field_name, $field_setting)
+        $block_display_config->setComponent($field_name, $field_setting)
           ->save();
-
-        unset($tile_block_form_config, $tile_block_display_config);
       }
+
+      unset($block_form_config, $block_display_config);
     }
   }
 }

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.install
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.install
@@ -16,145 +16,160 @@ use Drupal\field\Entity\FieldConfig;
  * Create block content type and fields used by the tile layout in the theme companion.
  */
 function trpcultivatetheme_companion_install() {
-  // All content assets (field and storage) go into this bundle.
-  $tile_content = 'trpcultivatetheme_tile_block';
-
-  // Tile field schema.
-  // Field name length cannot be more than 32 chars (prefix is 23 chars).
-  // Field types: drupal.org/docs/drupal-apis/entity-api/fieldtypes-fieldwidgets-and-fieldformatters
-  $field_prefix = 'trpcultivatetheme_tile_';
-  $tile_fields = [
-    // Tile title text.
-    $field_prefix . 'title' => [
-      'label' => 'Tile Title Text',
-      'weight' => 0,
-      'type' => [
-        'storage' => 'string',
-        'display' => 'basic_string',
-        'form' => 'string_textarea'
+  $content_schema = [
+    // TILES:
+    'trpcultivatetheme_tile_block' => [
+      'block' => [
+        'label' => 'Tripal Cultivate Theme Tile Block',
+        'description' => 'This block content type is used to insert content into tiles'
       ],
-      'settings' => [
-        'placeholder' => 'eg. New Bioinformatics Tools Launch',
-        'max_length' => 255
-      ] 
-    ],
-    
-    // Tile link (url) and text combo.
-    $field_prefix . 'link' => [
-      'label' => 'Tile Link (URL)',
-      'weight' => 1,
-      'type' => [
-        'storage' => 'link',
-        'display' => 'uri_link', 
-        'form' => 'link_default'
+      'fieldset' => [
+        'trpcultivatetheme_tile_title'    => [
+          'label' => 'Tile Title Text',
+          'weight' => 0,
+          'type' => [
+            'storage' => 'string',
+            'display' => 'basic_string',
+            'form' => 'string_textarea'
+          ],
+          'settings' => [
+            'placeholder' => 'eg. New Bioinformatics Tools Launch',
+            'max_length' => 255
+          ]
+        ],
+        'trpcultivatetheme_tile_link'     => [
+          'label' => 'Tile Link (URL)',
+          'weight' => 1,
+          'type' => [
+            'storage' => 'link',
+            'display' => 'uri_link', 
+            'form' => 'link_default'
+          ],
+          'settings' => [
+            'link_type' => 'url',
+            'protocols' => ['http', 'https']
+          ] 
+        ],
+        'trpcultivatetheme_tile_coverimg' => [
+          'label' => 'Tile Cover Image (JPG, GIF, WEBP or PNG)',
+          'weight' => 2,
+          'type' => [
+            'storage' => 'image',
+            'display' => 'file_uri',
+            'form' => 'image_image'
+          ],
+          'settings' => ['file_extensions' => 'jpg jpeg gif webp png']  
+        ],
+        'trpcultivatetheme_tile_bgcolor'  => [
+          'label' => 'Tile Background Colour',
+          'weight' => 3,
+          'type' => [
+            'storage' => 'string',
+            'display' => 'basic_string',
+            'form' => 'string_textarea'
+          ],
+          'settings' => [
+            'placeholder' => 'eg. #000000 for black',
+            'max_length' => 7
+          ] 
+        ],
       ],
-      'settings' => [
-        'link_type' => 'url',
-        'protocols' => ['http', 'https']
-      ] 
-    ],
-
-    // Tile cover image.
-    $field_prefix . 'coverimg' => [
-      'label' => 'Tile Cover Image (JPG, GIF, WEBP or PNG)',
-      'weight' => 2,
-      'type' => [
-        'storage' => 'image',
-        'display' => 'file_uri',
-        'form' => 'image_image'
-      ],
-      'settings' => ['file_extensions' => 'jpg jpeg gif webp png']
-    ],
-
-    // Tile background colour.
-    $field_prefix . 'bgcolor' => [
-      'label' => 'Tile Background Colour',
-      'weight' => 3,
-      'type' => [
-        'storage' => 'string',
-        'display' => 'basic_string',
-        'form' => 'string_textarea'
-      ],
-      'settings' => [
-        'placeholder' => 'eg. #000000 for black',
-        'max_length' => 7
-      ]
     ],
 
-    // Additional fields here.
-    // NOTE the field name character limit.
+    // MAIN CONTENT:
+    'trpcultivatetheme_content_block' => [
+      'block' => [
+        'label' => 'Tripal Cultivate Theme Main Content Block',
+        'description' => 'This block content type is used to insert content into main content section'
+      ],
+      'fieldset' => [
+        'trpcultivatetheme_content_title1' => [
+          'label' => 'Left Article: Title Text',
+          'weight' => 0,
+          'type' => [
+            'storage' => 'string',
+            'display' => 'basic_string',
+            'form' => 'string_textarea'
+          ],
+          'settings' => [
+            'placeholder' => 'eg. KnowPulse: A Web-Resource Focused on Diversity Data for Pulse Crop Improvement',
+            'max_length' => 255
+          ]
+        ],
+      ],
+    ],
   ];
   
+  // Create content block.
+  foreach ($content_schema as $bundle => $schema) {
+    // All content assets (field and storage) go into this bundle.
+    // Prepare storage, containers and configuration for the field.
 
-  // Prepare storage, containers and configuration for the field.
-
-  // Ensure that block type does not exists.
-  $block_exists = BlockContentType::load($tile_content);
-
-  if (!$block_exists) {
-    // Create the block type.
-    // @see admin/structure/block-content.
-    $tile_block = [
-      'id' => $tile_content,
-      'label' => 'Tripal Cultivate Theme Tile Block',
-      'description' => 'This block content type is used to insert content into tiles'
-    ];
-
-    BlockContentType::create($tile_block)
-      ->save();
-
-    $block_type = [
-      'targetEntityType' => 'block_content',
-      'bundle'  => $tile_content,
-      'status' => TRUE,
-      'mode'  => 'default',
-    ];
-
-    // Create block form display configuration.
-    // @see admin/structure/block-content - Manage Form tab.
-    $tile_block_form_config = EntityFormDisplay::create($block_type); 
-
-    // Create block type display configuration.
-    // @see admin/structure/block-content - Manage Display tab.
-    $tile_block_display_config = EntityViewDisplay::create($block_type);
+    // Ensure that block type does not exists.
+    $block_exists = BlockContentType::load($bundle);
     
-    
-    foreach($tile_fields as $field_name => $fieldprop) {
-      // Create storage.
-      FieldStorageConfig::create([
-        'field_name' => $field_name,
-        'entity_type' => 'block_content',
-        'type' => $fieldprop['type']['storage'],
-        'settings' => $fieldprop['settings']
-      ])
+    if (!$block_exists) {
+      // Create the block type.
+      // @see admin/structure/block-content.
+      $block = $schema['block'] + ['id' => $bundle]; 
+
+      BlockContentType::create($block)
         ->save();
 
-      // Attach to type.
-      FieldConfig::create([
-        'field_name' => $field_name,
-        'entity_type' => 'block_content',
-        'bundle' => $tile_content,
-        'label' => $fieldprop['label']
-      ])
-        ->save();
-
-      // Enable field.
-      $field_setting = [
-        'weight'  => $fieldprop['weight'],
-        'hidden' => FALSE,
-        'label' => 'hidden',
-        'settings' => $fieldprop['settings']
+      $block_type = [
+        'targetEntityType' => 'block_content',
+        'bundle'  => $bundle,
+        'status' => TRUE,
+        'mode'  => 'default',
       ];
+      
+      // Create block form display configuration.
+      // @see admin/structure/block-content - Manage Form tab.
+      $tile_block_form_config = EntityFormDisplay::create($block_type); 
 
-      // Form:
-      $field_setting['type'] = $fieldprop['type']['form'];
-      $tile_block_form_config->setComponent($field_name, $field_setting)
-        ->save();
+      // Create block type display configuration.
+      // @see admin/structure/block-content - Manage Display tab.
+      $tile_block_display_config = EntityViewDisplay::create($block_type);
+      
+      foreach($schema['fieldset'] as $field_name => $field_prop) {
+        // Create storage.
+        FieldStorageConfig::create([
+          'field_name' => $field_name,
+          'entity_type' => 'block_content',
+          'type' => $field_prop['type']['storage'],
+          'settings' => $field_prop['settings']
+        ])
+          ->save();
 
-      // Display:
-      $field_setting['type'] = $fieldprop['type']['display'];
-      $tile_block_display_config->setComponent($field_name, $field_setting)
-        ->save();
+        // Attach to type.
+        FieldConfig::create([
+          'field_name' => $field_name,
+          'entity_type' => 'block_content',
+          'bundle' => $bundle,
+          'label' => $field_prop['label']
+        ])
+          ->save();
+
+        // Enable field.
+        $field_setting = [
+          'weight'  => $field_prop['weight'],
+          'hidden' => FALSE,
+          'label' => 'hidden',
+          'settings' => $field_prop['settings']
+        ];
+
+        // Form:
+        $field_setting['type'] = $field_prop['type']['form'];
+        $tile_block_form_config->setComponent($field_name, $field_setting)
+          ->save();
+
+        // Display:
+        $field_setting['type'] = $field_prop['type']['display'];
+        $tile_block_display_config->setComponent($field_name, $field_setting)
+          ->save();
+
+        unset($tile_block_form_config, $tile_block_display_config);
+      }
     }
   }
 }

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.install
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.install
@@ -16,145 +16,233 @@ use Drupal\field\Entity\FieldConfig;
  * Create block content type and fields used by the tile layout in the theme companion.
  */
 function trpcultivatetheme_companion_install() {
-  // All content assets (field and storage) go into this bundle.
-  $tile_content = 'trpcultivatetheme_tile_block';
-
-  // Tile field schema.
-  // Field name length cannot be more than 32 chars (prefix is 23 chars).
-  // Field types: drupal.org/docs/drupal-apis/entity-api/fieldtypes-fieldwidgets-and-fieldformatters
-  $field_prefix = 'trpcultivatetheme_tile_';
-  $tile_fields = [
-    // Tile title text.
-    $field_prefix . 'title' => [
-      'label' => 'Tile Title Text',
-      'weight' => 0,
-      'type' => [
-        'storage' => 'string',
-        'display' => 'basic_string',
-        'form' => 'string_textarea'
+  $content_schema = [
+    // TILES:
+    'trpcultivatetheme_tile_block' => [
+      'block' => [
+        'label' => 'Tripal Cultivate Theme Tile Block',
+        'description' => 'This block content type is used to insert content into tiles'
       ],
-      'settings' => [
-        'placeholder' => 'eg. New Bioinformatics Tools Launch',
-        'max_length' => 255
-      ] 
-    ],
-    
-    // Tile link (url) and text combo.
-    $field_prefix . 'link' => [
-      'label' => 'Tile Link (URL)',
-      'weight' => 1,
-      'type' => [
-        'storage' => 'link',
-        'display' => 'uri_link', 
-        'form' => 'link_default'
+      'fieldset' => [
+        'trpcultivatetheme_tile_title'    => [
+          'label' => 'Tile Title Text',
+          'weight' => 0,
+          'type' => [
+            'storage' => 'string',
+            'display' => 'basic_string',
+            'form' => 'string_textarea'
+          ],
+          'settings' => [
+            'placeholder' => 'eg. New Bioinformatics Tools Launch',
+            'max_length' => 255
+          ]
+        ],
+        'trpcultivatetheme_tile_link'     => [
+          'label' => 'Tile Link (URL)',
+          'weight' => 1,
+          'type' => [
+            'storage' => 'link',
+            'display' => 'uri_link', 
+            'form' => 'link_default'
+          ],
+          'settings' => [
+            'link_type' => 'url',
+            'protocols' => ['http', 'https']
+          ] 
+        ],
+        'trpcultivatetheme_tile_coverimg' => [
+          'label' => 'Tile Cover Image (JPG, GIF, WEBP or PNG)',
+          'weight' => 2,
+          'type' => [
+            'storage' => 'image',
+            'display' => 'file_uri',
+            'form' => 'image_image'
+          ],
+          'settings' => ['file_extensions' => 'jpg jpeg gif webp png']  
+        ],
+        'trpcultivatetheme_tile_bgcolor'  => [
+          'label' => 'Tile Background Colour',
+          'weight' => 3,
+          'type' => [
+            'storage' => 'string',
+            'display' => 'basic_string',
+            'form' => 'string_textarea'
+          ],
+          'settings' => [
+            'placeholder' => 'eg. #000000 for black',
+            'max_length' => 7
+          ] 
+        ],
       ],
-      'settings' => [
-        'link_type' => 'url',
-        'protocols' => ['http', 'https']
-      ] 
-    ],
-
-    // Tile cover image.
-    $field_prefix . 'coverimg' => [
-      'label' => 'Tile Cover Image (JPG, GIF, WEBP or PNG)',
-      'weight' => 2,
-      'type' => [
-        'storage' => 'image',
-        'display' => 'file_uri',
-        'form' => 'image_image'
-      ],
-      'settings' => ['file_extensions' => 'jpg jpeg gif webp png']
-    ],
-
-    // Tile background colour.
-    $field_prefix . 'bgcolor' => [
-      'label' => 'Tile Background Colour',
-      'weight' => 3,
-      'type' => [
-        'storage' => 'string',
-        'display' => 'basic_string',
-        'form' => 'string_textarea'
-      ],
-      'settings' => [
-        'placeholder' => 'eg. #000000 for black',
-        'max_length' => 7
-      ]
     ],
 
-    // Additional fields here.
-    // NOTE the field name character limit.
+    // MAIN CONTENT:
+    'trpcultivatetheme_content_block' => [
+      'block' => [
+        'label' => 'Tripal Cultivate Theme Main Content Block',
+        'description' => 'This block content type is used to insert content into main content section'
+      ],
+      'fieldset' => [
+        // LEFT Article.
+        'trpcultivatetheme_content_title1' => [
+          'label' => 'Left Article: Title Text',
+          'weight' => 0,
+          'type' => [
+            'storage' => 'string',
+            'display' => 'basic_string',
+            'form' => 'string_textarea'
+          ],
+          'settings' => [
+            'placeholder' => 'eg. KnowPulse: A Web-Resource Focused on Diversity Data for Pulse Crop Improvement',
+            'max_length' => 255
+          ]
+        ],
+        'trpcultivatetheme_content_text1' => [
+          'label' => 'Left Article: Summary Text',
+          'weight' => 1,
+          'type' => [
+            'storage' => 'text_long',
+            'display' => 'text_default',
+            'form' => 'text_textarea'
+          ],
+          'settings' => [
+            'rows' => 5
+          ]
+        ],
+
+        // RIGHT Article.
+        'trpcultivatetheme_content_title2' => [
+          'label' => 'Right Article: Title Text',
+          'weight' => 2,
+          'type' => [
+            'storage' => 'string',
+            'display' => 'basic_string',
+            'form' => 'string_textarea'
+          ],
+          'settings' => [
+            'placeholder' => 'eg. KnowPulse: A Web-Resource Focused on Diversity Data for Pulse Crop Improvement',
+            'max_length' => 255
+          ]
+        ],
+        'trpcultivatetheme_content_text2' => [
+          'label' => 'Right Article: Summary Text',
+          'weight' => 3,
+          'type' => [
+            'storage' => 'text_long',
+            'display' => 'text_default',
+            'form' => 'text_textarea'
+          ],
+          'settings' => [
+            'rows' => 5
+          ]
+        ],
+      ],
+    ],
+
+    // FUNDER LOGO:
+    'trpcultivatetheme_content_block' => [
+      'block' => [
+        'label' => 'Tripal Cultivate Theme Funder Content Block',
+        'description' => 'This block content type is used to insert a funder into funders section'
+      ],
+      'fieldset' => [
+        'trpcultivatetheme_funders_logo' => [
+          'label' => 'Funder Logo (JPG, GIF, WEBP or PNG)',
+          'weight' => 0,
+          'type' => [
+            'storage' => 'image',
+            'display' => 'file_uri',
+            'form' => 'image_image'
+          ],
+          'settings' => ['file_extensions' => 'jpg jpeg gif webp png'] 
+        ],
+        'trpcultivatetheme_funders_link' => [
+          'label' => 'Funder Homepage',
+          'weight' => 1,
+          'type' => [
+            'storage' => 'string',
+            'display' => 'basic_string',
+            'form' => 'string_textarea'
+          ],
+          'settings' => [
+            'placeholder' => 'eg. https://knowpulse.usask.ca',
+            'max_length' => 255
+          ]
+        ]
+      ],
+    ],
   ];
   
+  // Create content block.
+  foreach ($content_schema as $bundle => $schema) {
+    // All content assets (field and storage) go into this bundle.
+    // Prepare storage, containers and configuration for the field.
 
-  // Prepare storage, containers and configuration for the field.
-
-  // Ensure that block type does not exists.
-  $block_exists = BlockContentType::load($tile_content);
-
-  if (!$block_exists) {
-    // Create the block type.
-    // @see admin/structure/block-content.
-    $tile_block = [
-      'id' => $tile_content,
-      'label' => 'Tripal Cultivate Theme Tile Block',
-      'description' => 'This block content type is used to insert content into tiles'
-    ];
-
-    BlockContentType::create($tile_block)
-      ->save();
-
-    $block_type = [
-      'targetEntityType' => 'block_content',
-      'bundle'  => $tile_content,
-      'status' => TRUE,
-      'mode'  => 'default',
-    ];
-
-    // Create block form display configuration.
-    // @see admin/structure/block-content - Manage Form tab.
-    $tile_block_form_config = EntityFormDisplay::create($block_type); 
-
-    // Create block type display configuration.
-    // @see admin/structure/block-content - Manage Display tab.
-    $tile_block_display_config = EntityViewDisplay::create($block_type);
+    // Ensure that block type does not exists.
+    $block_exists = BlockContentType::load($bundle);
     
-    
-    foreach($tile_fields as $field_name => $fieldprop) {
-      // Create storage.
-      FieldStorageConfig::create([
-        'field_name' => $field_name,
-        'entity_type' => 'block_content',
-        'type' => $fieldprop['type']['storage'],
-        'settings' => $fieldprop['settings']
-      ])
+    if (!$block_exists) {
+      // Create the block type.
+      // @see admin/structure/block-content.
+      $block = $schema['block'] + ['id' => $bundle]; 
+
+      BlockContentType::create($block)
         ->save();
 
-      // Attach to type.
-      FieldConfig::create([
-        'field_name' => $field_name,
-        'entity_type' => 'block_content',
-        'bundle' => $tile_content,
-        'label' => $fieldprop['label']
-      ])
-        ->save();
-
-      // Enable field.
-      $field_setting = [
-        'weight'  => $fieldprop['weight'],
-        'hidden' => FALSE,
-        'label' => 'hidden',
-        'settings' => $fieldprop['settings']
+      $block_type = [
+        'targetEntityType' => 'block_content',
+        'bundle'  => $bundle,
+        'status' => TRUE,
+        'mode'  => 'default',
       ];
+      
+      // Create block form display configuration.
+      // @see admin/structure/block-content - Manage Form tab.
+      $block_form_config = EntityFormDisplay::create($block_type); 
 
-      // Form:
-      $field_setting['type'] = $fieldprop['type']['form'];
-      $tile_block_form_config->setComponent($field_name, $field_setting)
-        ->save();
+      // Create block type display configuration.
+      // @see admin/structure/block-content - Manage Display tab.
+      $block_display_config = EntityViewDisplay::create($block_type);
+      
+      foreach($schema['fieldset'] as $field_name => $field_prop) {
+        // Create storage.
+        FieldStorageConfig::create([
+          'field_name' => $field_name,
+          'entity_type' => 'block_content',
+          'type' => $field_prop['type']['storage'],
+          'settings' => $field_prop['settings']
+        ])
+          ->save();
 
-      // Display:
-      $field_setting['type'] = $fieldprop['type']['display'];
-      $tile_block_display_config->setComponent($field_name, $field_setting)
-        ->save();
+        // Attach to type.
+        FieldConfig::create([
+          'field_name' => $field_name,
+          'entity_type' => 'block_content',
+          'bundle' => $bundle,
+          'label' => $field_prop['label']
+        ])
+          ->save();
+
+        // Enable field.
+        $field_setting = [
+          'weight'  => $field_prop['weight'],
+          'hidden' => FALSE,
+          'label' => 'hidden',
+          'settings' => $field_prop['settings']
+        ];
+
+        // Form:
+        $field_setting['type'] = $field_prop['type']['form'];
+        $block_form_config->setComponent($field_name, $field_setting)
+          ->save();
+
+        // Display:
+        $field_setting['type'] = $field_prop['type']['display'];
+        $block_display_config->setComponent($field_name, $field_setting)
+          ->save();
+      }
+
+      unset($block_form_config, $block_display_config);
     }
   }
 }

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.module
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.module
@@ -1,4 +1,10 @@
 <?php
+
+/**
+ * @file:
+ * Provides hook implementations for Tripal Cultivate Theme.
+ */
+
 use \Drupal\block\Entity\Block;
 use Drupal\Core\Session\AccountInterface;
 
@@ -47,6 +53,11 @@ function trpcultivatetheme_companion_block_access(Block $block, $operation, Acco
       array_push($trpcultivatetheme_regions, $region_name);
     }
   }
+
+  $region_to_content = [
+    'tiles' => 'trpcultivatetheme_tile_block',
+    'funders' => 'trpcultivatetheme_funder_block'
+  ];
   
   // The region the content is about to be placed.
   $block_region = $block->getRegion();
@@ -63,18 +74,20 @@ function trpcultivatetheme_companion_block_access(Block $block, $operation, Acco
       // Ensure that only tile block contents get processed.
       $block_dependencies = $block->getDependencies();
       $is_not_compatible = FALSE;
-      
+
       // Tile block content has content key in block dependencies (#dependencies) object,
       // test if block had content and if content was of type tile/funders block.
+      if (!isset($block_dependencies['content'])) {
+        // Has no content.
+        $is_not_compatible = TRUE;
+      }
+      
       if (isset($block_dependencies['content'])) {
         // Has content.
-        if (!str_contains($block_dependencies['content'][0], 'trpcultivatetheme_tile_block')) {
+        $block_check = str_contains($block_region, 'tiles') ? $region_to_content['tiles'] : $region_to_content['funders'];  
+        if (!preg_match('/' . $block_check . '/', $block_dependencies['content'][0])) {
           $is_not_compatible = TRUE;
         }
-      }
-      else {
-        // No content.
-        $is_not_compatible = TRUE;
       }
 
       if ($is_not_compatible) {

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.module
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.module
@@ -65,15 +65,15 @@ function trpcultivatetheme_companion_block_access(Block $block, $operation, Acco
       
       // Tile block content has content key in block dependencies (#dependencies) object,
       // test if block had content and if content was of type tile block.
-      if (isset($block_dependencies['content'][0])) {
-        // No content.
-        $is_not_tile = TRUE;
-      }
-      else {
+      if (isset($block_dependencies['content'])) {
         // Has content.
         if (!str_contains($block_dependencies['content'][0], 'trpcultivatetheme_tile_block')) {
           $is_not_tile = TRUE;
         }
+      }
+      else {
+        // No content.
+        $is_not_tile = TRUE;
       }
 
       if ($is_not_tile) {

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.module
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.module
@@ -39,7 +39,7 @@ function trpcultivatetheme_companion_block_access(Block $block, $operation, Acco
   $regions = system_region_list($def_theme);
   
   // Extract only the trpcultivatetheme_tiles custom regions.
-  $trpcultivatetheme_tiles_regions = []; 
+  $trpcultivatetheme_tiles_regions = [];
   
   foreach($regions as $region_name => $_) {
     if (preg_match('/^' . $def_theme . '_tiles/', $region_name)) {
@@ -59,14 +59,24 @@ function trpcultivatetheme_companion_block_access(Block $block, $operation, Acco
     if ($block_id) {
       // @debug dpm($block);
 
-      // Tile content is a block content type and id is a hash value
-      // ie. block_content:58dad12f-a9e4-4305-a082-d370ae079137.
-      // @see hook_install().
-      // Content is block_content plus unique id number since multiple instance can be created.
-    
-      if (!preg_match('/^block_content:/', $block_id)) {  
-        // The content id does not match the tripalcultivatetheme tile content id format.
-        
+      // Ensure that only tile block contents get processed.
+      $block_dependencies = $block->getDependencies();
+      $is_not_tile = FALSE;
+      
+      // Tile block content has content key in block dependencies (#dependencies) object,
+      // test if block had content and if content was of type tile block.
+      if (isset($block_dependencies['content'][0])) {
+        // No content.
+        $is_not_tile = TRUE;
+      }
+      else {
+        // Has content.
+        if (!str_contains($block_dependencies['content'][0], 'trpcultivatetheme_tile_block')) {
+          $is_not_tile = TRUE;
+        }
+      }
+
+      if ($is_not_tile) {
         $error_message = 'A non-compatible content was added to Tripal Cultivate Theme Tiles region. ';
         $error_message .= 'BLOCK: '. ucwords(str_replace('_', ' ', $block_id)) . ' REGION: ' . ucwords(str_replace('_', ' ', $block_region));
 

--- a/trpcultivatetheme_companion/trpcultivatetheme_companion.module
+++ b/trpcultivatetheme_companion/trpcultivatetheme_companion.module
@@ -39,18 +39,19 @@ function trpcultivatetheme_companion_block_access(Block $block, $operation, Acco
   $regions = system_region_list($def_theme);
   
   // Extract only the trpcultivatetheme_tiles custom regions.
-  $trpcultivatetheme_tiles_regions = []; 
+  $trpcultivatetheme_regions = [];
   
+  // Watch for contents placed into tiles and funders regions.
   foreach($regions as $region_name => $_) {
-    if (preg_match('/^' . $def_theme . '_tiles/', $region_name)) {
-      array_push($trpcultivatetheme_tiles_regions, $region_name);
+    if (preg_match('/^' . $def_theme . '(_tiles|_contents_funders)/', $region_name)) {
+      array_push($trpcultivatetheme_regions, $region_name);
     }
-  } 
+  }
   
   // The region the content is about to be placed.
   $block_region = $block->getRegion();
 
-  if ($block_region && in_array($block_region, $trpcultivatetheme_tiles_regions) && $operation == 'update') {
+  if ($block_region && in_array($block_region, $trpcultivatetheme_regions) && $operation == 'update') {
     // When updating a region by placing a content block into any of the tiles region.
     
     // The id of the content.
@@ -59,16 +60,26 @@ function trpcultivatetheme_companion_block_access(Block $block, $operation, Acco
     if ($block_id) {
       // @debug dpm($block);
 
-      // Tile content is a block content type and id is a hash value
-      // ie. block_content:58dad12f-a9e4-4305-a082-d370ae079137.
-      // @see hook_install().
-      // Content is block_content plus unique id number since multiple instance can be created.
-    
-      if (!preg_match('/^block_content:/', $block_id)) {  
-        // The content id does not match the tripalcultivatetheme tile content id format.
-        
-        $error_message = 'A non-compatible content was added to Tripal Cultivate Theme Tiles region. ';
-        $error_message .= 'BLOCK: '. ucwords(str_replace('_', ' ', $block_id)) . ' REGION: ' . ucwords(str_replace('_', ' ', $block_region));
+      // Ensure that only tile block contents get processed.
+      $block_dependencies = $block->getDependencies();
+      $is_not_compatible = FALSE;
+      
+      // Tile block content has content key in block dependencies (#dependencies) object,
+      // test if block had content and if content was of type tile/funders block.
+      if (isset($block_dependencies['content'])) {
+        // Has content.
+        if (!str_contains($block_dependencies['content'][0], 'trpcultivatetheme_tile_block')) {
+          $is_not_compatible = TRUE;
+        }
+      }
+      else {
+        // No content.
+        $is_not_compatible = TRUE;
+      }
+
+      if ($is_not_compatible) {
+        $error_message = 'A non-compatible content was added to ' .  ucwords(str_replace('_', ' ', $block_region)) . ' region. ';
+        $error_message .= 'BLOCK: '. ucwords(str_replace('_', ' ', $block_id));
 
         // Logs an error
         \Drupal::logger('trpcultivatetheme_companion')


### PR DESCRIPTION
This PR adds footer section.
![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/e79d0715-cf35-416f-a3d4-dbed55952870)

The footer section of the base theme is setup so that there is a top footer section and a bottom footer section. A default content block title Powered By Drupal is added to the bottom footer and might require deleting it.

![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/4fc1236e-a637-4b38-8c2c-8c438dce4571)

To Test:
1. In my site/block/add?destination=/admin/content/block create a Basic block
![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/bdbffe56-3c87-4ce1-9ed9-0d36501ef808)

2. Use the text editor to layout the content for the footer.

![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/5f1b1067-4bf8-4b68-967a-4c63634d8115)
3. Click save
4. Place the footer content into Footer Top region in my site/admin/structure/block configuration page. Uncheck the Display title option .
![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/15472253/5435b725-1f42-4b6c-a911-0fcb911a0602)
5. Click save, clear cache and reload homepage.
6. Repeat to add content to footer bottom region


