### PR TITLE
Grant Cards

### DIFF
--- a/trpcultivatetheme/css/base/elements.css
+++ b/trpcultivatetheme/css/base/elements.css
@@ -1,0 +1,3 @@
+:root {
+  --border-color-primary-80: hsl(var(--color--primary-hue), var(--color--primary-saturation), calc(1% * (var(--color--primary-lightness) + (0.80 * (100 - var(--color--primary-lightness))))));
+}

--- a/trpcultivatetheme/css/base/elements.css
+++ b/trpcultivatetheme/css/base/elements.css
@@ -1,3 +1,4 @@
 :root {
+  --color--primary-70: hsl(var(--color--primary-hue), var(--color--primary-saturation), calc(1% * (var(--color--primary-lightness) + (0.75 * (100 - var(--color--primary-lightness))))));
   --border-color-primary-80: hsl(var(--color--primary-hue), var(--color--primary-saturation), calc(1% * (var(--color--primary-lightness) + (0.80 * (100 - var(--color--primary-lightness))))));
 }

--- a/trpcultivatetheme/css/component/grant-card.css
+++ b/trpcultivatetheme/css/component/grant-card.css
@@ -12,6 +12,7 @@
   padding: var(--sp2);
   line-height: 24px;
   hyphens: none;
+  position: relative;
 }
 
 .embedded-grant-activity {
@@ -20,6 +21,7 @@
   padding: 0;
   line-height: 24px;
   hyphens: none;
+  position: relative;
 }
 
 /** Remove link underlines */

--- a/trpcultivatetheme/css/component/grant-card.css
+++ b/trpcultivatetheme/css/component/grant-card.css
@@ -1,0 +1,99 @@
+/**
+ * Component: Grant Card
+ * Tripal Content: Research Grant
+ * View Mode: Embedded in Child
+ * Paired with template tripal-entity--research-grant--embedded-in-child.html.twig
+ */
+.embedded-grant {
+  color: var(--color-text-primary-loud);
+  background-color: var(--color--primary-80);
+  border: 1px solid var(--border-color-primary-80);
+  padding: var(--sp2);
+  line-height: 24px;
+}
+
+/** Remove container highlighting for this specific entity reference field */
+.field--type-entity-reference>.field__item:has(> .embedded-grant),
+.field--type-entity-reference>.field__items>.field__item:has(> .embedded-grant) {
+  background-color: transparent;
+  padding: 0;
+  margin-bottom: 0;
+}
+
+/** Card Layout */
+.embedded-grant {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.embedded-grant .grant-card {
+  flex-grow: 0;
+  flex-shrink: 1;
+}
+
+.embedded-grant .grant-card.left {
+  text-align: center;
+  width: 19%;
+}
+
+.embedded-grant .grant-card.right {
+  width: 79%;
+  padding-left: 10px;
+}
+
+/** Field specific modifications */
+.embedded-grant .field--name-title {
+  font-weight: bolder;
+  font-size: 1em;
+  margin-block-end: 0;
+  margin-bottom: var(--sp0-5);
+}
+
+.embedded-grant a {
+  text-decoration: none;
+}
+
+.embedded-grant .field--name-grant-custodian {
+  font-size: 0.8em;
+  line-height: 0.8em;
+}
+
+.embedded-grant .field--name-grant-org {
+  font-size: 0.7em;
+  line-height: 0.7em;
+  font-style: italic;
+}
+
+.embedded-grant .field--name-grant-funding-range {
+  text-align: right;
+  position: absolute;
+  bottom: var(--sp2);
+  right: var(--sp2);
+}
+
+/** Make contact lists into comma separated ones. */
+.embedded-grant .field--type-chado-contact-by-role-type-default {
+  display: inline;
+  list-style: none;
+}
+
+.embedded-grant .field--type-chado-contact-by-role-type-default ul {
+  margin-inline-start: 0;
+}
+
+.embedded-grant .field--type-chado-contact-by-role-type-default li {
+  display: inline;
+}
+
+.embedded-grant .field--type-chado-contact-by-role-type-default li:before {
+  content: ", ";
+}
+
+.embedded-grant .field--type-chado-contact-by-role-type-default li:first-child:before {
+  content: "";
+}
+
+.embedded-grant .field--type-chado-contact-by-role-type-default li:last-child:before {
+  content: " and ";
+}

--- a/trpcultivatetheme/css/component/grant-card.css
+++ b/trpcultivatetheme/css/component/grant-card.css
@@ -1,8 +1,9 @@
 /**
  * Component: Grant Card
- * Tripal Content: Research Grant
+ * Tripal Content: Research Grant, Research Grant Activity
  * View Mode: Embedded in Child
  * Paired with template tripal-entity--research-grant--embedded-in-child.html.twig
+ * and tripal-entity--grant-section--embedded-in-child.html.twig
  */
 .embedded-grant {
   color: var(--color-text-primary-loud);
@@ -10,11 +11,27 @@
   border: 1px solid var(--border-color-primary-80);
   padding: var(--sp2);
   line-height: 24px;
+  hyphens: none;
 }
 
-/** Remove container highlighting for this specific entity reference field */
+.embedded-grant-activity {
+  background-color: var(--color--primary-70);
+  border: 1px solid var(--border-color-primary-80);
+  padding: 0;
+  line-height: 24px;
+  hyphens: none;
+}
+
+/** Remove link underlines */
+.embedded-grant a, .embedded-grant-activity a {
+  text-decoration: none;
+}
+
+/** Remove container highlighting for these specific entity reference fields */
 .field--type-entity-reference>.field__item:has(> .embedded-grant),
-.field--type-entity-reference>.field__items>.field__item:has(> .embedded-grant) {
+.field--type-entity-reference>.field__items>.field__item:has(> .embedded-grant),
+.field--type-entity-reference>.field__item:has(> .embedded-grant-activity),
+.field--type-entity-reference>.field__items>.field__item:has(> .embedded-grant-activity) {
   background-color: transparent;
   padding: 0;
   margin-bottom: 0;
@@ -42,16 +59,13 @@
   padding-left: 10px;
 }
 
-/** Field specific modifications */
-.embedded-grant .field--name-title {
+/** Grant Field specific modifications */
+.embedded-grant .field--name-title,
+.embedded-grant-activity .field--name-title {
   font-weight: bolder;
   font-size: 1em;
   margin-block-end: 0;
   margin-bottom: var(--sp0-5);
-}
-
-.embedded-grant a {
-  text-decoration: none;
 }
 
 .embedded-grant .field--name-grant-custodian {
@@ -70,6 +84,15 @@
   position: absolute;
   bottom: var(--sp2);
   right: var(--sp2);
+}
+
+/** Grant Activity Field specific modifications */
+.embedded-grant-activity .field--name-title {
+  padding: var(--sp1) var(--sp2);
+  margin-bottom: 0;
+}
+.embedded-grant-activity .embedded-grant .field--name-title {
+  padding: 0;
 }
 
 /** Make contact lists into comma separated ones. */

--- a/trpcultivatetheme/templates/tripal-entity--grant-section--embedded-in-child.html.twig
+++ b/trpcultivatetheme/templates/tripal-entity--grant-section--embedded-in-child.html.twig
@@ -1,0 +1,21 @@
+{#
+/**
+ * @file tripal_entity.html.twig
+ * Default theme implementation to present Tripal Content data.
+ *
+ * This template is used when viewing Tripal Content pages.
+ *
+ *
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ * - attributes: HTML attributes for the container element.
+ *
+ * @see template_preprocess_tripal_entity()
+ *
+ * @ingroup themeable
+ */
+#}
+<div{{ attributes.addClass(['tripal_entity', 'embedded-grant-activity']) }}>
+  {{ content.title }}
+  {{ content.field_grant }}
+</div>

--- a/trpcultivatetheme/templates/tripal-entity--research-grant--embedded-in-child.html.twig
+++ b/trpcultivatetheme/templates/tripal-entity--research-grant--embedded-in-child.html.twig
@@ -1,0 +1,25 @@
+{#
+/**
+ * @file tripal_entity.html.twig
+ * Default theme implementation to present Tripal Content data.
+ *
+ * This template is used when viewing Tripal Content pages.
+ *
+ *
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ * - attributes: HTML attributes for the container element.
+ *
+ * @see template_preprocess_tripal_entity()
+ *
+ * @ingroup themeable
+ */
+#}
+<div{{ attributes.addClass(['tripal_entity', 'embedded-grant']) }}>
+  <div class="grant-card left">
+    {{ content.field_grant_logo }}
+  </div>
+  <div class="grant-card right">
+    {{ content|without(content.field_grant_logo) }}
+  </div>
+</div>

--- a/trpcultivatetheme/templates/tripal_entity.html.twig
+++ b/trpcultivatetheme/templates/tripal_entity.html.twig
@@ -1,0 +1,22 @@
+{#
+/**
+ * @file tripal_entity.html.twig
+ * Default theme implementation to present Tripal Content data.
+ *
+ * This template is used when viewing Tripal Content pages.
+ *
+ *
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ * - attributes: HTML attributes for the container element.
+ *
+ * @see template_preprocess_tripal_entity()
+ *
+ * @ingroup themeable
+ */
+#}
+<div{{ attributes.addClass('tripal_entity') }}>
+  {% if content %}
+    {{- content -}}
+  {% endif %}
+</div>

--- a/trpcultivatetheme/trpcultivatetheme.libraries.yml
+++ b/trpcultivatetheme/trpcultivatetheme.libraries.yml
@@ -14,6 +14,7 @@ global:
       css/component/footer.css: {}
       css/component/field.css: {}
       css/component/form.css: {}
+      css/component/grant-card.css: {}
       css/component/header.css: {}
       css/component/menu.css: {}
       css/component/messages.css: {}
@@ -23,6 +24,7 @@ global:
       css/component/tabs.css: {}
       css/component/buttons.css: {}
       css/component/slider.css: {}
+      css/component/tripal_content.css: {}
     layout:
       css/layout/layout.css: {}
       css/layout/layout-footer.css: {}


### PR DESCRIPTION
**Issue #34**

## Motivation
<!-- This can usually be copied from the issue.
     Please do not just say, go see issue but instead
    copy the relevant details here. -->
The default display of embedded grant information was really ugly 🤷‍♀️ 

## What does this PR do?
<!-- Please describe each things this PR does.
     For example, a PR may 1) solve a specific bug,
     2) create an automated test to ensure it doesn't return. -->

- [x] Add a few more CSS variables based on the primary theme colour.
- [x] Create templates for the embedded view mode of research grant and research activities
- [x] Use CSS to layout a card design with the logo on the left side and the text on the other.
- [x] Modify the Contact field to be a comma-separated list instead of a bulleted one.
- [x] Layout a template and CSS files to modify TripalContent pages in general.

## Testing

### Manual Testing
<!-- Describe in detail how someone should manually test this functionality.
     Make sure to include whether they need to build a docker from scratch,
     create any records, configure anything, etc. -->

This work was needed urgently and as such is already live on the activating crops site. As such you can test it by visiting the following pages.

For each page, test:

- the grant card displays properly
- when you resize the window, the grant card does not break alignment or proportions
- check the display is consistent with other pages of the same type

#### Grant Activity pages

The following screenshot shows what you should expect :-)

<img width="942" alt="Screenshot 2025-03-27 at 12 41 29 PM" src="https://github.com/user-attachments/assets/e13c3d1a-17fc-44b7-8e4f-6fb7d9270029" />

You can see this on the following pages:
- [activity](https://activating-crops.usask.ca/grant/ACTIVATE/4)
- [activity](https://activating-crops.usask.ca/grant/ACTIVATE/3.1)
- [activity](https://activating-crops.usask.ca/grant/ACTIVATE/2.2)
- [activity](https://activating-crops.usask.ca/grant/ACTIVATE/5)

#### Studies

Studies indicate the activity that they are part of in addition to the grant information. That's why you expect to see something like this:

<img width="801" alt="Screenshot 2025-03-27 at 12 49 51 PM" src="https://github.com/user-attachments/assets/9206ce3c-ca6f-4502-ac42-c313f64face1" />

You can see this on the following pages:

- [studies](https://activating-crops.usask.ca/research-study/95)
- [studies](https://activating-crops.usask.ca/research-study/98)
- [studies](https://activating-crops.usask.ca/research-study/103)
- [studies](https://activating-crops.usask.ca/research-study/109)

#### Experiments

Experiments only indicate the grant they are part of and so you expect them to look the same as the Grant Activities.

<img width="742" alt="Screenshot 2025-03-27 at 12 54 05 PM" src="https://github.com/user-attachments/assets/2c094e89-33e5-48fd-a182-5115cbe33ef3" />

You can see this on the following pages:

- [Experiment](https://activating-crops.usask.ca/experiment/Genotyping-of-200-diverse-lentil-lines)
- [Experiment](https://activating-crops.usask.ca/experiment/Tracing-15N-from-Lentil-Wheat-greenhouse-2023-2024)
- [Experiment](https://activating-crops.usask.ca/experiment/Tracing-15N-from-Lentil-Wheat-field-2024-2026)
- [Experiment](https://activating-crops.usask.ca/experiment/Soil-microbiome-associations-Lentil-Wheat-rotation-field-2023-2026)

